### PR TITLE
New date formatter for kinvey ISO dates

### DIFF
--- a/Kinvey/Kinvey.xcodeproj/project.pbxproj
+++ b/Kinvey/Kinvey.xcodeproj/project.pbxproj
@@ -416,6 +416,7 @@
 		57FEB6B91C8E480300B43FC0 /* SyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FEB6B81C8E480300B43FC0 /* SyncOperation.swift */; };
 		57FF4F6D1CCFE71B002947FF /* RemoveOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FF4F6C1CCFE71B002947FF /* RemoveOperation.swift */; };
 		57FF4F6F1CD02FF7002947FF /* OperationQueueRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FF4F6E1CD02FF7002947FF /* OperationQueueRequest.swift */; };
+		966B1D631DD6528000995A42 /* KinveyDateTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966B1D621DD6528000995A42 /* KinveyDateTransform.swift */; };
 		E9073D011C986D9600475E16 /* CustomEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9073D001C986D9600475E16 /* CustomEndpoint.swift */; };
 /* End PBXBuildFile section */
 
@@ -1014,6 +1015,7 @@
 		57FEB6B81C8E480300B43FC0 /* SyncOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncOperation.swift; sourceTree = "<group>"; };
 		57FF4F6C1CCFE71B002947FF /* RemoveOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoveOperation.swift; sourceTree = "<group>"; };
 		57FF4F6E1CD02FF7002947FF /* OperationQueueRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationQueueRequest.swift; sourceTree = "<group>"; };
+		966B1D621DD6528000995A42 /* KinveyDateTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KinveyDateTransform.swift; sourceTree = "<group>"; };
 		E9073D001C986D9600475E16 /* CustomEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomEndpoint.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1097,6 +1099,7 @@
 			children = (
 				572C458F1C86AC7C00A41935 /* ValueTransformer.swift */,
 				572C458D1C86A70000A41935 /* NSDate2StringValueTransformer.swift */,
+				966B1D621DD6528000995A42 /* KinveyDateTransform.swift */,
 			);
 			name = "Value Transformers";
 			sourceTree = "<group>";
@@ -2539,6 +2542,7 @@
 				57B23EB11C7FA59C006403CC /* DataStoreOperation.m in Sources */,
 				57B23EEF1C7FAA0C006403CC /* KCSNSURLSessionFileOperation.m in Sources */,
 				57B23F5C1C7FB1B6006403CC /* KCS_DDLog.m in Sources */,
+				966B1D631DD6528000995A42 /* KinveyDateTransform.swift in Sources */,
 				57B23F621C7FB1C6006403CC /* KCS_FMDatabaseAdditions.m in Sources */,
 				577E6FA81D18E45F00B5DA36 /* Executor.swift in Sources */,
 				57B23EDB1C7FA8A9006403CC /* KCSObjcRuntime.m in Sources */,

--- a/Kinvey/Kinvey/KinveyDateTransform.swift
+++ b/Kinvey/Kinvey/KinveyDateTransform.swift
@@ -15,14 +15,24 @@ class KinveyDateTransform : TransformType {
     public typealias Object = Date
     public typealias JSON = String
     
-    let dateFormatter: DateFormatter
+    let dateReadFormatter: DateFormatter
+    let dateWriteFormatter: DateFormatter
     
     public init() {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        //read formatter that accounts for the timezone
+        let rFormatter = DateFormatter()
+        rFormatter.locale = Locale(identifier: "en_US_POSIX")
+        rFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
         
-        self.dateFormatter = formatter
+        self.dateReadFormatter = rFormatter
+        
+        //write formatter for UTC
+        let wFormatter = DateFormatter()
+        wFormatter.locale = Locale(identifier: "en_US_POSIX")
+        wFormatter.timeZone = TimeZone(identifier: "UTC")
+        wFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        
+        self.dateWriteFormatter = wFormatter
     }
     
     open func transformFromJSON(_ value: Any?) -> Date? {
@@ -35,7 +45,7 @@ class KinveyDateTransform : TransformType {
             
             let match = matches(for: "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{3})?(([+-]\\d{4})|Z)", in: dateString)
             if match.count > 0 {
-                let matchedDate = dateFormatter.date(from: match[0])
+                let matchedDate = dateReadFormatter.date(from: match[0])
                 return matchedDate
             }
         }
@@ -44,7 +54,7 @@ class KinveyDateTransform : TransformType {
     
     open func transformToJSON(_ value: Date?) -> String? {
         if let date = value {
-            return dateFormatter.string(from: date)
+            return dateWriteFormatter.string(from: date)
         }
         return nil
     }

--- a/Kinvey/Kinvey/KinveyDateTransform.swift
+++ b/Kinvey/Kinvey/KinveyDateTransform.swift
@@ -1,0 +1,65 @@
+//
+//  KinveyDateTransform.swift
+//  Kinvey
+//
+//  Created by Tejas on 11/11/16.
+//  Copyright © 2016 Kinvey. All rights reserved.
+//
+
+import Foundation
+import ObjectMapper
+
+
+class KinveyDateTransform : TransformType {
+    
+    public typealias Object = Date
+    public typealias JSON = String
+    
+    let dateFormatter: DateFormatter
+    
+    public init() {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        
+        self.dateFormatter = formatter
+    }
+    
+    open func transformFromJSON(_ value: Any?) -> Date? {
+        if let dateString = value as? String {
+            
+            //Extract the matching date for the following types of strings
+            //yyyy-MM-dd'T'HH:mm:ss.SSS'Z' -> default date string written by this transform
+            //yyyy-MM-dd'T'HH:mm:ss.SSS+ZZZZ -> date with time offset (e.g. +0400, -0500)
+            //ISODate("yyyy-MM-dd'T'HH:mm:ss.SSSZ") -> backward compatible with Kinvey 1.x
+            
+            let match = matches(for: "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{3})?(([+-]\\d{4})|Z)", in: dateString)
+            if match.count > 0 {
+                let matchedDate = dateFormatter.date(from: match[0])
+                return matchedDate
+            }
+        }
+        return nil
+    }
+    
+    open func transformToJSON(_ value: Date?) -> String? {
+        if let date = value {
+            return dateFormatter.string(from: date)
+        }
+        return nil
+    }
+    
+    fileprivate func matches(for regex: String, in text: String) -> [String] {
+        
+        do {
+            let regex = try NSRegularExpression(pattern: regex)
+            let nsString = text as NSString
+            let results = regex.matches(in: text, range: NSRange(location: 0, length: nsString.length))
+            return results.map { nsString.substring(with: $0.range)}
+        } catch let error {
+            print("invalid regex: \(error.localizedDescription)")
+            return []
+        }
+    }
+    
+}

--- a/Kinvey/KinveyTests/DataTypeTestCase.swift
+++ b/Kinvey/KinveyTests/DataTypeTestCase.swift
@@ -15,10 +15,11 @@ class DataTypeTestCase: StoreTestCase {
     func testSave() {
         signUp()
         
-        let store = DataStore<DataType>.collection()
+        let store = DataStore<DataType>.collection(.network)
         let dataType = DataType()
         dataType.boolValue = true
         dataType.colorValue = UIColor.orange
+        
         
         let fullName = FullName()
         fullName.firstName = "Victor"
@@ -42,7 +43,7 @@ class DataTypeTestCase: StoreTestCase {
         
         weak var expectationFind = expectation(description: "Find")
         
-        store.find(query, readPolicy: .forceNetwork) { results, error in
+        store.find(query) { results, error in
             XCTAssertNotNil(results)
             XCTAssertNil(error)
             
@@ -76,6 +77,68 @@ class DataTypeTestCase: StoreTestCase {
         }
     }
     
+    func testDate() {
+        signUp()
+        
+        let store = DataStore<EntityWithDate>.collection(.network)
+        
+        let dateEntity = EntityWithDate()
+        dateEntity.date = Date()
+
+        let tuple = save(dateEntity, store: store)
+        XCTAssertNotNil(tuple.savedPersistable)
+
+        if let savedPersistable = tuple.savedPersistable {
+            XCTAssertTrue((savedPersistable.date != nil))
+        }
+
+        weak var expectationFind = expectation(description: "Find")
+        
+        let query = Query(format: "acl.creator == %@", client.activeUser!.userId)
+        
+        store.find(query) { results, error in
+            XCTAssertNotNil(results)
+            XCTAssertNil(error)
+            
+            if let results = results {
+                XCTAssertGreaterThan(results.count, 0)
+                
+                if let dataType = results.first {
+                    XCTAssertNotNil(dataType.date)
+                }
+            }
+            
+            expectationFind?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { (error) in
+            expectationFind = nil
+        }
+
+    }
+    
+    func testDateFormats() {
+        let transform = KinveyDateTransform()
+        XCTAssertEqual(transform.transformFromJSON("ISODate(\"2016-11-14T10:05:55.787Z\")"), Date(timeIntervalSince1970: 1479117955.787))
+        XCTAssertEqual(transform.transformFromJSON("2016-11-14T10:05:55.787Z"), Date(timeIntervalSince1970: 1479117955.787))
+        XCTAssertEqual(transform.transformFromJSON("2016-11-14T10:05:55.787-0500"), Date(timeIntervalSince1970: 1479135955.787))
+        XCTAssertEqual(transform.transformFromJSON("2016-11-14T10:05:55.787+0100"), Date(timeIntervalSince1970: 1479114355.787))
+    }
+    
+}
+
+class EntityWithDate : Entity {
+    dynamic var date:Date?
+    
+    override class func collectionName() -> String {
+        return "DataType"
+    }
+    
+    override func propertyMapping(_ map: Map) {
+        super.propertyMapping(map)
+        
+        date <- ("date", map["date"], KinveyDateTransform())
+    }
 }
 
 class UIColorTransformType : TransformType {
@@ -124,6 +187,8 @@ class DataType: Entity {
     
     dynamic var objectValue: NSObject?
     
+    //dynamic var dateValue: Date?
+    
     fileprivate dynamic var colorValueString: String?
     dynamic var colorValue: UIColor? {
         get {
@@ -159,6 +224,7 @@ class DataType: Entity {
         colorValue <- (map["colorValue"], UIColorTransformType())
         fullName <- map["fullName"]
         fullName2 <- (map["fullName2"], FullName2TransformType())
+        //dateValue <- (map["date"], KinveyDateTransform())
     }
     
     override class func ignoredProperties() -> [String] {


### PR DESCRIPTION
The ISO8601 Date Formatter in the ObjectMapper library is insufficient to handle all cases of Kinvey dates. This PR adds a formatter that supports the following formats - 

* yyyy-MM-dd'T'HH:mm:ss.SSS'Z' -> default date string written by this transform
* yyyy-MM-dd'T'HH:mm:ss.SSS+ZZZZ -> date with time offset (e.g. +0400, -0500)
* ISODate("yyyy-MM-dd'T'HH:mm:ss.SSSZ") -> backward compatible with Kinvey 1.x
