### PR TITLE
Added public initializer to KinveyDateTransform

### DIFF
--- a/Kinvey/Kinvey/KinveyDateTransform.swift
+++ b/Kinvey/Kinvey/KinveyDateTransform.swift
@@ -15,6 +15,8 @@ open class KinveyDateTransform : TransformType {
     public typealias Object = Date
     public typealias JSON = String
     
+    public init() {}
+    
     //read formatter that accounts for the timezone
     lazy var dateReadFormatter: DateFormatter = {
         let rFormatter = DateFormatter()


### PR DESCRIPTION
Fixed Jira ticket MLIBZ-1591. 

`KinveyDateTranform`did not have a public initializer, resulting in a compilation error when used outside the `Kinvey` module.