### PR TITLE
MLIBZ-1587: adding support for mapping array/list properties

### DIFF
--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -11,6 +11,8 @@ import Realm
 import RealmSwift
 import ObjectMapper
 
+public typealias List<T: RealmSwift.Object> = RealmSwift.List<T>
+
 internal func StringFromClass(cls: AnyClass) -> String {
     var className = NSStringFromClass(cls)
     let regex = try! NSRegularExpression(pattern: "RLM.+_.+") // regex to catch Realm classnames like `RLMStandalone_`, `RLMUnmanaged_` or `RLMAccessor_`
@@ -124,6 +126,106 @@ open class Entity: Object, Persistable {
         } else {
             self.propertyMapping(map)
         }
+    }
+    
+}
+
+open class StringValue: Object, ExpressibleByStringLiteral {
+    
+    public dynamic var value = ""
+    
+    public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+    
+    public convenience required init(unicodeScalarLiteral value: String) {
+        self.init()
+        self.value = value
+    }
+    
+    public convenience required init(extendedGraphemeClusterLiteral value: String) {
+        self.init()
+        self.value = value
+    }
+    
+    public convenience required init(stringLiteral value: String) {
+        self.init()
+        self.value = value
+    }
+    
+    public convenience init(_ value: String) {
+        self.init()
+        self.value = value
+    }
+    
+}
+
+open class IntValue: Object, ExpressibleByIntegerLiteral {
+    
+    public dynamic var value = 0
+    
+    public typealias IntegerLiteralType = Int
+    
+    public convenience required init(integerLiteral value: Int) {
+        self.init()
+        self.value = value
+    }
+    
+    public convenience init(_ value: Int) {
+        self.init()
+        self.value = value
+    }
+    
+}
+
+open class FloatValue: Object, ExpressibleByFloatLiteral {
+    
+    public dynamic var value = Float(0)
+    
+    public typealias FloatLiteralType = Float
+    
+    public convenience required init(floatLiteral value: Float) {
+        self.init()
+        self.value = value
+    }
+    
+    public convenience init(_ value: Float) {
+        self.init()
+        self.value = value
+    }
+    
+}
+
+open class DoubleValue: Object, ExpressibleByFloatLiteral {
+    
+    public dynamic var value = 0.0
+    
+    public typealias FloatLiteralType = Double
+    
+    public convenience required init(floatLiteral value: Double) {
+        self.init()
+        self.value = value
+    }
+    
+    public convenience init(_ value: Double) {
+        self.init()
+        self.value = value
+    }
+    
+}
+
+open class BoolValue: Object, ExpressibleByBooleanLiteral {
+    
+    public dynamic var value = false
+    
+    public typealias FloatLiteralType = BooleanLiteralType
+    
+    public convenience required init(booleanLiteral value: Bool) {
+        self.init()
+        self.value = value
+    }
+    
+    public convenience init(_ value: Bool) {
+        self.init()
+        self.value = value
     }
     
 }

--- a/Kinvey/Kinvey/Persistable.swift
+++ b/Kinvey/Kinvey/Persistable.swift
@@ -11,6 +11,9 @@ import CoreData
 import ObjectMapper
 import CoreLocation
 
+public typealias Map = ObjectMapper.Map
+infix operator <- : DefaultPrecedence
+
 /// Protocol that turns a NSObject into a persistable class to be used in a `DataStore`.
 public protocol Persistable: Mappable {
     
@@ -89,6 +92,186 @@ public func <- <Transform: TransformType>(left: inout Transform.Object?, right: 
 public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (String, Map, Transform)) {
     kinveyMappingType(left: right.0, right: right.1.currentKey!)
     left <- (right.1, right.2)
+}
+
+// MARK: String Value Transform
+
+class StringValueTransform: TransformOf<List<StringValue>, [String]> {
+    init() {
+        super.init(fromJSON: { (array: [String]?) -> List<StringValue>? in
+            if let array = array {
+                let list = List<StringValue>()
+                for item in array {
+                    list.append(StringValue(item))
+                }
+                return list
+            }
+            return nil
+        }, toJSON: { (list: List<StringValue>?) -> [String]? in
+            if let list = list {
+                return list.map { $0.value }
+            }
+            return nil
+        })
+    }
+}
+
+/// Override operator used during the `propertyMapping(_:)` method.
+public func <- (left: List<StringValue>, right: (String, Map)) {
+    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    var list = left
+    switch right.1.mappingType {
+    case .toJSON:
+        list <- (right.1, StringValueTransform())
+    case .fromJSON:
+        list <- (right.1, StringValueTransform())
+        left.removeAll()
+        left.append(objectsIn: list)
+    }
+}
+
+// MARK: Int Value Transform
+
+class IntValueTransform: TransformOf<List<IntValue>, [Int]> {
+    init() {
+        super.init(fromJSON: { (array: [Int]?) -> List<IntValue>? in
+            if let array = array {
+                let list = List<IntValue>()
+                for item in array {
+                    list.append(IntValue(item))
+                }
+                return list
+            }
+            return nil
+        }, toJSON: { (list: List<IntValue>?) -> [Int]? in
+            if let list = list {
+                return list.map { $0.value }
+            }
+            return nil
+        })
+    }
+}
+
+/// Override operator used during the `propertyMapping(_:)` method.
+public func <- (left: List<IntValue>, right: (String, Map)) {
+    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    var list = left
+    switch right.1.mappingType {
+    case .toJSON:
+        list <- (right.1, IntValueTransform())
+    case .fromJSON:
+        list <- (right.1, IntValueTransform())
+        left.removeAll()
+        left.append(objectsIn: list)
+    }
+}
+
+// MARK: Float Value Transform
+
+class FloatValueTransform: TransformOf<List<FloatValue>, [Float]> {
+    init() {
+        super.init(fromJSON: { (array: [Float]?) -> List<FloatValue>? in
+            if let array = array {
+                let list = List<FloatValue>()
+                for item in array {
+                    list.append(FloatValue(item))
+                }
+                return list
+            }
+            return nil
+        }, toJSON: { (list: List<FloatValue>?) -> [Float]? in
+            if let list = list {
+                return list.map { $0.value }
+            }
+            return nil
+        })
+    }
+}
+
+/// Override operator used during the `propertyMapping(_:)` method.
+public func <- (left: List<FloatValue>, right: (String, Map)) {
+    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    var list = left
+    switch right.1.mappingType {
+    case .toJSON:
+        list <- (right.1, FloatValueTransform())
+    case .fromJSON:
+        list <- (right.1, FloatValueTransform())
+        left.removeAll()
+        left.append(objectsIn: list)
+    }
+}
+
+// MARK: Double Value Transform
+
+class DoubleValueTransform: TransformOf<List<DoubleValue>, [Double]> {
+    init() {
+        super.init(fromJSON: { (array: [Double]?) -> List<DoubleValue>? in
+            if let array = array {
+                let list = List<DoubleValue>()
+                for item in array {
+                    list.append(DoubleValue(item))
+                }
+                return list
+            }
+            return nil
+        }, toJSON: { (list: List<DoubleValue>?) -> [Double]? in
+            if let list = list {
+                return list.map { $0.value }
+            }
+            return nil
+        })
+    }
+}
+
+/// Override operator used during the `propertyMapping(_:)` method.
+public func <- (left: List<DoubleValue>, right: (String, Map)) {
+    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    var list = left
+    switch right.1.mappingType {
+    case .toJSON:
+        list <- (right.1, DoubleValueTransform())
+    case .fromJSON:
+        list <- (right.1, DoubleValueTransform())
+        left.removeAll()
+        left.append(objectsIn: list)
+    }
+}
+
+// MARK: Bool Value Transform
+
+class BoolValueTransform: TransformOf<List<BoolValue>, [Bool]> {
+    init() {
+        super.init(fromJSON: { (array: [Bool]?) -> List<BoolValue>? in
+            if let array = array {
+                let list = List<BoolValue>()
+                for item in array {
+                    list.append(BoolValue(item))
+                }
+                return list
+            }
+            return nil
+        }, toJSON: { (list: List<BoolValue>?) -> [Bool]? in
+            if let list = list {
+                return list.map { $0.value }
+            }
+            return nil
+        })
+    }
+}
+
+/// Override operator used during the `propertyMapping(_:)` method.
+public func <- (left: List<BoolValue>, right: (String, Map)) {
+    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    var list = left
+    switch right.1.mappingType {
+    case .toJSON:
+        list <- (right.1, BoolValueTransform())
+    case .fromJSON:
+        list <- (right.1, BoolValueTransform())
+        left.removeAll()
+        left.append(objectsIn: list)
+    }
 }
 
 internal let KinveyMappingTypeKey = "Kinvey Mapping Type"

--- a/Kinvey/Kinvey/Query.swift
+++ b/Kinvey/Kinvey/Query.swift
@@ -55,7 +55,7 @@ public final class Query: NSObject, BuilderType, Mappable {
     /// Impose a limit of records in the results of the query.
     open var limit: Int?
     
-    fileprivate func translateExpression(_ expression: NSExpression) -> NSExpression {
+    internal func translate(expression: NSExpression) -> NSExpression {
         switch expression.expressionType {
         case .keyPath:
             var keyPath = expression.keyPath
@@ -78,11 +78,11 @@ public final class Query: NSObject, BuilderType, Mappable {
         }
     }
     
-    fileprivate func translatePredicate(_ predicate: NSPredicate) -> NSPredicate {
+    fileprivate func translate(predicate: NSPredicate) -> NSPredicate {
         if let predicate = predicate as? NSComparisonPredicate {
             return NSComparisonPredicate(
-                leftExpression: translateExpression(predicate.leftExpression),
-                rightExpression: translateExpression(predicate.rightExpression),
+                leftExpression: translate(expression: predicate.leftExpression),
+                rightExpression: translate(expression: predicate.rightExpression),
                 modifier: predicate.comparisonPredicateModifier,
                 type: predicate.predicateOperatorType,
                 options: predicate.options
@@ -90,7 +90,7 @@ public final class Query: NSObject, BuilderType, Mappable {
         } else if let predicate = predicate as? NSCompoundPredicate {
             var subpredicates = [NSPredicate]()
             for predicate in predicate.subpredicates as! [NSPredicate] {
-                subpredicates.append(translatePredicate(predicate))
+                subpredicates.append(translate(predicate: predicate))
             }
             return NSCompoundPredicate(type: predicate.compoundPredicateType, subpredicates: subpredicates)
         }
@@ -104,7 +104,7 @@ public final class Query: NSObject, BuilderType, Mappable {
     fileprivate var queryStringEncoded: String? {
         get {
             if let predicate = predicate {
-                let translatedPredicate = translatePredicate(predicate)
+                let translatedPredicate = translate(predicate: predicate)
                 let queryObj = translatedPredicate.mongoDBQuery!
                 
                 let data = try! JSONSerialization.data(withJSONObject: queryObj, options: [])

--- a/Kinvey/KinveyTests/Book.swift
+++ b/Kinvey/KinveyTests/Book.swift
@@ -7,11 +7,15 @@
 //
 
 import Kinvey
-import ObjectMapper
 
 class Book: Entity {
     
     dynamic var title: String?
+    let authorNames = List<StringValue>()
+    let editionsYear = List<IntValue>()
+    let editionsRetailPrice = List<FloatValue>()
+    let editionsRating = List<DoubleValue>()
+    let editionsAvailable = List<BoolValue>()
     
     override class func collectionName() -> String {
         return "Book"
@@ -20,9 +24,12 @@ class Book: Entity {
     override func propertyMapping(_ map: Map) {
         super.propertyMapping(map)
         
-        Kinvey.sharedClient.timeoutInterval = 120 //2 minutes timeout
-        
         title <- ("title", map["title"])
+        authorNames <- ("authorNames", map["authorNames"])
+        editionsYear <- ("editionsYear", map["editionsYear"])
+        editionsRetailPrice <- ("editionsRetailPrice", map["editionsRetailPrice"])
+        editionsRating <- ("editionsRating", map["editionsRating"])
+        editionsAvailable <- ("editionsAvailable", map["editionsAvailable"])
     }
     
 }

--- a/Kinvey/KinveyTests/QueryTest.swift
+++ b/Kinvey/KinveyTests/QueryTest.swift
@@ -243,4 +243,40 @@ class QueryTest: XCTestCase {
         XCTAssertEqual(result, expected)
     }
     
+    func testArrayContains() {
+        let cache = RealmCache<Book>(persistenceId: "_kid_", schemaVersion: 0)
+        let predicate = cache.translate(predicate: NSPredicate(format: "authorNames contains %@", "Victor"))
+        XCTAssertEqual(predicate, NSPredicate(format: "SUBQUERY(authorNames, $item, $item.value == %@).@count > 0", "Victor"))
+    }
+    
+    func testArrayIndex() {
+        let cache = RealmCache<Book>(persistenceId: "_kid_", schemaVersion: 0)
+        let predicate = cache.translate(predicate: NSPredicate(format: "authorNames[0] == %@", "Victor"))
+        XCTAssertEqual(predicate, NSPredicate(format: "authorNames[0].value == %@", "Victor"))
+    }
+    
+    func testArrayFirst() {
+        let cache = RealmCache<Book>(persistenceId: "_kid_", schemaVersion: 0)
+        let predicate = cache.translate(predicate: NSPredicate(format: "authorNames[first] == %@", "Victor"))
+        XCTAssertEqual(predicate, NSPredicate(format: "authorNames[first].value == %@", "Victor"))
+    }
+    
+    func testArrayLast() {
+        let cache = RealmCache<Book>(persistenceId: "_kid_", schemaVersion: 0)
+        let predicate = cache.translate(predicate: NSPredicate(format: "authorNames[last] == %@", "Victor"))
+        XCTAssertEqual(predicate, NSPredicate(format: "authorNames[last].value == %@", "Victor"))
+    }
+    
+    func testArraySize() {
+        let cache = RealmCache<Book>(persistenceId: "_kid_", schemaVersion: 0)
+        let predicate = cache.translate(predicate: NSPredicate(format: "authorNames[size] == 2"))
+        XCTAssertEqual(predicate, NSPredicate(format: "authorNames[size] == 2"))
+    }
+    
+    func testArraySubquery() {
+        let cache = RealmCache<Book>(persistenceId: "_kid_", schemaVersion: 0)
+        let predicate = cache.translate(predicate: NSPredicate(format: "subquery(authorNames, $authorNames, $authorNames like[c] %@).$count > 0", "Vic*"))
+        XCTAssertEqual(predicate, NSPredicate(format: "subquery(authorNames, $authorNames, $authorNames.value like[c] %@).$count > 0", "Vic*"))
+    }
+    
 }


### PR DESCRIPTION
#### Description

This is a solution to solve the limitation around mapping arrays in your entity class.

#### Changes

- Creating new types that are literal convertible like `String`, `Int`, `Float`, `Double` and `Bool`
- Adding new `Transform` types to convert between `List` and `Array` values
- Overloading the `<-` operator in order to use the `Transform` types above

#### Tests

- Tested converting queries when running against the local cache. Queries like:
`authorNames contains 'Victor'`
`subquery(authorNames, $authorNames, $authorNames like[c] 'Vic*').$count > 0`
