### PR TITLE
Pass options dictionary through to KCSClient.initializeKinveyService()

### DIFF
--- a/Kinvey/Kinvey/Client.swift
+++ b/Kinvey/Kinvey/Client.swift
@@ -203,7 +203,7 @@ open class Client: NSObject, NSCoding, Credential {
     }
     
     /// Initialize a `Client` instance with all the needed parameters.
-    open func initialize(appKey: String, appSecret: String, apiHostName: URL = Client.defaultApiHostName, authHostName: URL = Client.defaultAuthHostName, encryptionKey: Data? = nil, schemaVersion: CUnsignedLongLong = 0, migrationHandler: Migration.MigrationHandler? = nil) {
+    open func initialize(appKey: String, appSecret: String, apiHostName: URL = Client.defaultApiHostName, authHostName: URL = Client.defaultAuthHostName, encryptionKey: Data? = nil, schemaVersion: CUnsignedLongLong = 0, options: [String: Any]? = nil, migrationHandler: Migration.MigrationHandler? = nil) {
         validateInitialize(appKey: appKey, appSecret: appSecret)
         
         self.encryptionKey = encryptionKey
@@ -228,7 +228,7 @@ open class Client: NSObject, NSCoding, Credential {
         self.appSecret = appSecret
         
         //legacy initilization
-        KCSClient.shared().initializeKinveyService(forAppKey: appKey, withAppSecret: appSecret, usingOptions: nil)
+        KCSClient.shared().initializeKinveyService(forAppKey: appKey, withAppSecret: appSecret, usingOptions: options)
         
         if let json = Foundation.UserDefaults.standard.object(forKey: appKey) as? [String : AnyObject] {
             let user = Mapper<User>().map(JSON: json)

--- a/Kinvey/Kinvey/KNVClient.m
+++ b/Kinvey/Kinvey/KNVClient.m
@@ -79,6 +79,7 @@
                           apiHostName:apiHostName
                          authHostName:authHostName
                         schemaVersion:0
+                              options:nil
                      migrationHandler:nil];
 }
 
@@ -87,6 +88,7 @@
                         apiHostName:(NSURL *)apiHostName
                        authHostName:(NSURL *)authHostName
                       schemaVersion:(unsigned long long)schemaVersion
+                            options:(NSDictionary<NSString *, id> *)options
                    migrationHandler:(KNVMigrationBlock)migrationHandler
 {
     [self.client initializeWithAppKey:appKey
@@ -95,6 +97,7 @@
                          authHostName:authHostName
                         encryptionKey:nil
                         schemaVersion:schemaVersion
+                              options:options
                      migrationHandler:migrationHandler];
     return self;
 }

--- a/KinveyKit/KinveyKit/Source/KCSClient.h
+++ b/KinveyKit/KinveyKit/Source/KCSClient.h
@@ -76,7 +76,7 @@ KCS_CONSTANT KCSNetworkConnectionDidEnd;
 @property (nonatomic, copy, readonly) NSString *appSecret;
 
 /*! Configuration options, set via @see initializeKinveyServiceForAppKey:withAppSecret:usingOptions */
-@property (nonatomic, strong, readonly) NSDictionary *options;
+@property (nonatomic, strong, readonly) NSDictionary<NSString *, id> *options;
 
 ///---------------------------------------------------------------------------------------
 /// @name Library Information
@@ -196,7 +196,7 @@ KCS_CONSTANT KCSNetworkConnectionDidEnd;
  */
 - (instancetype)initializeKinveyServiceForAppKey:(NSString *)appKey
                                    withAppSecret:(NSString *)appSecret
-                                    usingOptions:(NSDictionary *)options;
+                                    usingOptions:(NSDictionary<NSString *, id> *)options;
 
 /*! Initialize the singleton KCSClient with this application's key and the secret for this app, along with any needed options.
  
@@ -229,7 +229,7 @@ KCS_CONSTANT KCSNetworkConnectionDidEnd;
  */
 - (instancetype)initializeKinveyServiceForAppKey:(NSString *)appKey
                                    withAppSecret:(NSString *)appSecret
-                                    usingOptions:(NSDictionary *)options
+                                    usingOptions:(NSDictionary<NSString *, id> *)options
                             requestConfiguration:(KCSRequestConfiguration*)requestConfiguration;
 
 /*! Initialize the singleton KCSClient with a dictionary plist containing options to run

--- a/KinveyKit/KinveyKit/Source/KCSClient.m
+++ b/KinveyKit/KinveyKit/Source/KCSClient.m
@@ -148,7 +148,7 @@
     return self.configuration.serviceHostname;
 }
 
-- (NSDictionary *)options
+- (NSDictionary<NSString *, id> *)options
 {
     return self.configuration.options;
 }
@@ -183,7 +183,7 @@
 
 - (instancetype) initializeKinveyServiceForAppKey:(NSString *)appKey
                                     withAppSecret:(NSString *)appSecret
-                                     usingOptions:(NSDictionary *)options
+                                     usingOptions:(NSDictionary<NSString *, id> *)options
 {
     return [self initializeKinveyServiceForAppKey:appKey
                                     withAppSecret:appSecret
@@ -193,7 +193,7 @@
 
 - (instancetype) initializeKinveyServiceForAppKey:(NSString *)appKey
                                     withAppSecret:(NSString *)appSecret
-                                     usingOptions:(NSDictionary *)options
+                                     usingOptions:(NSDictionary<NSString *, id> *)options
                              requestConfiguration:(KCSRequestConfiguration *)requestConfiguration
 {
     [self initializeWithConfiguration:[KCSClientConfiguration configurationWithAppKey:appKey

--- a/KinveyKit/KinveyKit/Source/KCSClientConfiguration.h
+++ b/KinveyKit/KinveyKit/Source/KCSClientConfiguration.h
@@ -134,7 +134,7 @@ KCS_CONSTANT KCS_ALWAYS_USE_NSURLREQUEST;
  - KCS_DATE_FORMAT -- the format used for date parsing
  
  */
-@property (nonatomic, copy) NSDictionary* options;
+@property (nonatomic, copy) NSDictionary<NSString*, id>* options;
 
 /*! Subdomain used to connect to the backend server. Default value: "baas". Sample values: "foo-baas" or "foo-baas.". */
 @property (nonatomic, copy) NSString* serviceHostname;
@@ -190,7 +190,7 @@ KCS_CONSTANT KCS_ALWAYS_USE_NSURLREQUEST;
  */
 + (instancetype) configurationWithAppKey:(NSString*)appKey
                                   secret:(NSString*)appSecret
-                                 options:(NSDictionary*)options;
+                                 options:(NSDictionary<NSString*, id>*)options;
 
 /** Basic configuration with an app key and secret and options.
  
@@ -211,7 +211,7 @@ KCS_CONSTANT KCS_ALWAYS_USE_NSURLREQUEST;
  */
 + (instancetype) configurationWithAppKey:(NSString*)appKey
                                   secret:(NSString*)appSecret
-                                 options:(NSDictionary*)options
+                                 options:(NSDictionary<NSString*, id>*)options
                     requestConfiguration:(KCSRequestConfiguration*)requestConfiguration;
 
 /** Builds the configuration from the specified plist.

--- a/KinveyKit/KinveyKit/Source/KCSClientConfiguration.m
+++ b/KinveyKit/KinveyKit/Source/KCSClientConfiguration.m
@@ -120,7 +120,7 @@ KCS_CONST_IMPL KCS_ALWAYS_USE_NSURLREQUEST = @"KCS_ALWAYS_USE_NSURLREQUEST";
 
 + (instancetype)configurationWithAppKey:(NSString *)appKey
                                  secret:(NSString *)appSecret
-                                options:(NSDictionary *)optionsDictionary
+                                options:(NSDictionary<NSString *, id> *)optionsDictionary
 {
     return [self configurationWithAppKey:appKey
                                   secret:appSecret
@@ -130,7 +130,7 @@ KCS_CONST_IMPL KCS_ALWAYS_USE_NSURLREQUEST = @"KCS_ALWAYS_USE_NSURLREQUEST";
 
 + (instancetype)configurationWithAppKey:(NSString *)appKey
                                  secret:(NSString *)appSecret
-                                options:(NSDictionary *)optionsDictionary
+                                options:(NSDictionary<NSString *, id> *)optionsDictionary
                    requestConfiguration:(KCSRequestConfiguration *)requestConfiguration
 {
     KCSClientConfiguration* config = nil;

--- a/KinveyKit/KinveyKit/Source/KCSHttpRequest+Private.h
+++ b/KinveyKit/KinveyKit/Source/KCSHttpRequest+Private.h
@@ -27,7 +27,7 @@
 @property (nonatomic, copy) NSString* contentType;
 @property (nonatomic, weak) id<KCSCredentials> credentials;
 @property (nonatomic, retain) NSString* route;
-@property (nonatomic, copy) NSDictionary* options;
+@property (nonatomic, copy) NSDictionary<NSString*, id>* options;
 @property (nonatomic, strong) KNVClient* client;
 
 +(NSMutableURLRequest *)requestForURL:(NSURL *)url

--- a/KinveyKit/KinveyKit/Source/KCSHttpRequest.h
+++ b/KinveyKit/KinveyKit/Source/KCSHttpRequest.h
@@ -66,18 +66,18 @@ typedef void(^KCSRequestCompletionBlock)(KCSNetworkResponse* response, NSError*e
 
 + (instancetype) requestWithCompletion:(KCSRequestCompletionBlock)completion
                                  route:(NSString*)route
-                               options:(NSDictionary*)options
+                               options:(NSDictionary<NSString*, id>*)options
                            credentials:(id)credentials;
 
 + (instancetype) requestWithCompletion:(KCSRequestCompletionBlock)completion
                                  route:(NSString*)route
-                               options:(NSDictionary*)options
+                               options:(NSDictionary<NSString*, id>*)options
                            credentials:(id)credentials
                                 client:(KNVClient*)client;
 
 + (instancetype) requestWithCompletion:(KCSRequestCompletionBlock)completion
                                  route:(NSString*)route
-                               options:(NSDictionary*)options
+                               options:(NSDictionary<NSString*, id>*)options
                            credentials:(id)credentials
                   requestConfiguration:(KCSRequestConfiguration*)requestConfiguration;
 

--- a/KinveyKit/KinveyKit/Source/KCSHttpRequest.m
+++ b/KinveyKit/KinveyKit/Source/KCSHttpRequest.m
@@ -103,7 +103,7 @@ static NSOperationQueue* kcsRequestQueue;
 
 + (instancetype) requestWithCompletion:(KCSRequestCompletionBlock)completion
                                  route:(NSString*)route
-                               options:(NSDictionary*)options
+                               options:(NSDictionary<NSString*, id>*)options
                            credentials:(id)credentials
 {
     return [self requestWithCompletion:completion
@@ -115,7 +115,7 @@ static NSOperationQueue* kcsRequestQueue;
 
 + (instancetype) requestWithCompletion:(KCSRequestCompletionBlock)completion
                                  route:(NSString*)route
-                               options:(NSDictionary*)options
+                               options:(NSDictionary<NSString*, id>*)options
                            credentials:(id)credentials
                                 client:(KNVClient*)client
 {
@@ -129,7 +129,7 @@ static NSOperationQueue* kcsRequestQueue;
 
 + (instancetype) requestWithCompletion:(KCSRequestCompletionBlock)completion
                                  route:(NSString*)route
-                               options:(NSDictionary*)options
+                               options:(NSDictionary<NSString*, id>*)options
                            credentials:(id)credentials
                   requestConfiguration:(KCSRequestConfiguration*)requestConfiguration
 {
@@ -143,7 +143,7 @@ static NSOperationQueue* kcsRequestQueue;
 
 + (instancetype) requestWithCompletion:(KCSRequestCompletionBlock)completion
                                  route:(NSString*)route
-                               options:(NSDictionary*)options
+                               options:(NSDictionary<NSString*, id>*)options
                            credentials:(id)credentials
                   requestConfiguration:(KCSRequestConfiguration*)requestConfiguration
                                 client:(KNVClient*)client


### PR DESCRIPTION
#### Description
The new `Client` API doesn't provide a way to pass an options dictionary when initialising the legacy Kinvey service. This change adds a new options parameter and passes it through to `KSCClient.initializeKinveyService()`.

#### Changes
In addition to passing through the `options` dictionary, this change also introduces generic type parameters to the dictionary. This will cause a warning when using something other than an `NSString *` key, and causes the dictionary to bridge to Swift 3 as `[String: Any]`.

#### Tests
No new tests were added.
