### PR TITLE
MLIBZ-1394: Better error message

### DIFF
--- a/Kinvey/Kinvey/Error.swift
+++ b/Kinvey/Kinvey/Error.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Enum that contains all error types in the library.
-public enum Error: Swift.Error, CustomStringConvertible, CustomDebugStringConvertible {
+public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomDebugStringConvertible {
     
     /// Constant for 401 responses where the credentials are not enough to complete the request.
     public static let InsufficientCredentials = "InsufficientCredentials"
@@ -56,9 +56,6 @@ public enum Error: Swift.Error, CustomStringConvertible, CustomDebugStringConver
     /// Error when a `User` doen't have an email or username.
     case userWithoutEmailOrUsername
     
-    var error: NSError {
-        return self as NSError
-    }
     
     /// Error localized description.
     public var description: String {
@@ -87,6 +84,14 @@ public enum Error: Swift.Error, CustomStringConvertible, CustomDebugStringConver
         case .userWithoutEmailOrUsername:
             return NSLocalizedString("Error.userWithoutEmailOrUsername", bundle: bundle, comment: "")
         }
+    }
+    
+    public var errorDescription: String? {
+        return description
+    }
+    
+    public var failureReason: String? {
+        return description
     }
     
     public var debugDescription: String {

--- a/Kinvey/KinveyTests/ErrorTestCase.swift
+++ b/Kinvey/KinveyTests/ErrorTestCase.swift
@@ -11,38 +11,38 @@ import XCTest
 
 class ErrorTestCase: KinveyTestCase {
     
-    override func setUp() {
-    }
-    
-    override func tearDown() {
-    }
-    
     func testObjectIDMissing() {
-        XCTAssertEqual("\(Kinvey.Error.objectIdMissing)", "Object ID is required and is missing")
+        let expectedDescription = "Object ID is required and is missing"
+        XCTAssertEqual("\(Kinvey.Error.objectIdMissing)", expectedDescription)
+        XCTAssertEqual(Kinvey.Error.objectIdMissing.description, expectedDescription)
+        XCTAssertEqual(Kinvey.Error.objectIdMissing.localizedDescription, expectedDescription)
+        XCTAssertEqual(Kinvey.Error.objectIdMissing.failureReason, expectedDescription)
+        XCTAssertEqual((Kinvey.Error.objectIdMissing as NSError).localizedDescription, expectedDescription)
+        XCTAssertEqual((Kinvey.Error.objectIdMissing as NSError).localizedFailureReason, expectedDescription)
     }
     
     func testInvalidResponse() {
-        XCTAssertEqual("\(Kinvey.Error.invalidResponse(httpResponse: nil, data: nil))", "Invalid response from the server")
+        XCTAssertEqual(Kinvey.Error.invalidResponse(httpResponse: nil, data: nil).description, "Invalid response from the server")
     }
     
     func testUnauthorized() {
-        XCTAssertEqual("\(Kinvey.Error.unauthorized(httpResponse: nil, data: nil, error: "Error", description: "Description"))", "Description")
+        XCTAssertEqual(Kinvey.Error.unauthorized(httpResponse: nil, data: nil, error: "Error", description: "Description").description, "Description")
     }
     
     func testNoActiveUser() {
-        XCTAssertEqual("\(Kinvey.Error.noActiveUser)", "An active user is required and none was found")
+        XCTAssertEqual(Kinvey.Error.noActiveUser.description, "An active user is required and none was found")
     }
     
     func testRequestCancelled() {
-        XCTAssertEqual("\(Kinvey.Error.requestCancelled)", "Request was cancelled")
+        XCTAssertEqual(Kinvey.Error.requestCancelled.description, "Request was cancelled")
     }
     
     func testInvalidDataStoreType() {
-        XCTAssertEqual("\(Kinvey.Error.invalidDataStoreType)", "DataStore type does not support this operation")
+        XCTAssertEqual(Kinvey.Error.invalidDataStoreType.description, "DataStore type does not support this operation")
     }
     
     func testUserWithoutEmailOrUsername() {
-        XCTAssertEqual("\(Kinvey.Error.userWithoutEmailOrUsername)", "User has no email or username")
+        XCTAssertEqual(Kinvey.Error.userWithoutEmailOrUsername.description, "User has no email or username")
     }
     
     func testInvalidResponseHttpResponseData() {

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -209,7 +209,7 @@ class SyncStoreTests: StoreTestCase {
             XCTAssertNotNil(error)
             
             if let error = error as? NSError {
-                XCTAssertEqual(error, Kinvey.Error.invalidDataStoreType.error)
+                XCTAssertEqual(error, Kinvey.Error.invalidDataStoreType as NSError)
             }
             
             expectationPurge?.fulfill()
@@ -656,7 +656,7 @@ class SyncStoreTests: StoreTestCase {
             XCTAssertNotNil(error)
             
             if let error = error as? NSError {
-                XCTAssertEqual(error, Kinvey.Error.invalidDataStoreType.error)
+                XCTAssertEqual(error, Kinvey.Error.invalidDataStoreType as NSError)
             }
             
             expectationPull?.fulfill()


### PR DESCRIPTION
#### Description

Better error messages for `Kinvey.Error` objects as described in the issue https://github.com/Kinvey/ios-library/issues/173

#### Changes

`Kinvey.Error` now conforms to `LocalizedError`

#### Tests

Unit Test changed accordingly
