### PR TITLE
MLIBZ-1167: Geolocation Queries

### DIFF
--- a/Carthage/Checkouts/NSPredicate-MongoDB-Adaptor/MongoDBPredicateAdaptor.m
+++ b/Carthage/Checkouts/NSPredicate-MongoDB-Adaptor/MongoDBPredicateAdaptor.m
@@ -553,7 +553,7 @@ NSString *const jsEqualsOperator = @"===";
             CLLocationCoordinate2D coord = coords[i];
             coordArray[i] = @[@(coord.longitude),@(coord.latitude)];
         }
-        result = @{@"$geometry":@{@"type":@"Polygon", @"coordinates":coordArray}};        
+        result = @{@"$polygon":coordArray};        
     }
     return result;
 }

--- a/Kinvey/Kinvey.xcodeproj/project.pbxproj
+++ b/Kinvey/Kinvey.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		57A4658E1CC02AE6009E7384 /* KinveyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A27C901C178F18000DF951 /* KinveyTestCase.swift */; };
 		57A4658F1CC02AEF009E7384 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571991081CB45EEE00070CDA /* Person.swift */; };
 		57A465921CC030AF009E7384 /* Kinvey.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57A27C811C178F17000DF951 /* Kinvey.framework */; };
+		57A526531E42A07900B33A51 /* Geolocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A526521E42A07900B33A51 /* Geolocation.swift */; };
 		57A9609D1CC6D675005E52A8 /* DirectoryEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A9609C1CC6D675005E52A8 /* DirectoryEntry.swift */; };
 		57A9609F1CC6D6A9005E52A8 /* RefProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A9609E1CC6D6A9005E52A8 /* RefProject.swift */; };
 		57A960A11CC6D6FE005E52A8 /* JsonTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A960A01CC6D6FE005E52A8 /* JsonTestCase.swift */; };
@@ -660,6 +661,7 @@
 		57A4656E1CC00931009E7384 /* PerformanceTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTestCase.swift; sourceTree = "<group>"; };
 		57A465821CC02A59009E7384 /* KinveyAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KinveyAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		57A465861CC02A59009E7384 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		57A526521E42A07900B33A51 /* Geolocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Geolocation.swift; sourceTree = "<group>"; };
 		57A9609C1CC6D675005E52A8 /* DirectoryEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectoryEntry.swift; sourceTree = "<group>"; };
 		57A9609E1CC6D6A9005E52A8 /* RefProject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefProject.swift; sourceTree = "<group>"; };
 		57A960A01CC6D6FE005E52A8 /* JsonTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JsonTestCase.swift; sourceTree = "<group>"; };
@@ -1085,6 +1087,7 @@
 				577E6FA31D18B33900B5DA36 /* Results.swift */,
 				577E6FA71D18E45F00B5DA36 /* Executor.swift */,
 				57C2F1721D5E5A68005A214B /* BuilderType.swift */,
+				57A526521E42A07900B33A51 /* Geolocation.swift */,
 			);
 			path = Kinvey;
 			sourceTree = "<group>";
@@ -1961,6 +1964,7 @@
 				57BB56B41C4D8D2B00F6B548 /* LocalRequest.swift in Sources */,
 				57FF4F6F1CD02FF7002947FF /* OperationQueueRequest.swift in Sources */,
 				57E1C3A71C17B4F300578974 /* Persistable.swift in Sources */,
+				57A526531E42A07900B33A51 /* Geolocation.swift in Sources */,
 				57FB57D91C86581300AA590F /* String.swift in Sources */,
 				57E7C7AF1C50539200848748 /* Sync.swift in Sources */,
 				574B0FAB1C729EC900CDC48F /* SaveOperation.swift in Sources */,

--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -116,7 +116,7 @@ open class Entity: Object, Persistable {
             operationQueue.maxConcurrentOperationCount = 1
             operationQueue.addOperation {
                 let className = StringFromClass(cls: type(of: self))
-                Thread.current.threadDictionary[KinveyMappingTypeKey] = [className : [String : String]()]
+                Thread.current.threadDictionary[KinveyMappingTypeKey] = [className : PropertyMap()]
                 self.propertyMapping(map)
                 originalThread.threadDictionary[KinveyMappingTypeKey] = Thread.current.threadDictionary[KinveyMappingTypeKey]
             }

--- a/Kinvey/Kinvey/Geolocation.swift
+++ b/Kinvey/Kinvey/Geolocation.swift
@@ -1,0 +1,106 @@
+//
+//  Geolocation.swift
+//  Kinvey
+//
+//  Created by Victor Hugo on 2017-02-01.
+//  Copyright © 2017 Kinvey. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+import ObjectMapper
+import CoreLocation
+import MapKit
+
+open class GeoPoint: Object, Mappable {
+    
+    open dynamic var latitude: CLLocationDegrees = 0.0
+    open dynamic var longitude: CLLocationDegrees = 0.0
+    
+    public convenience required init?(map: Map) {
+        guard let _: Double = map["latitude"].value(), let _: Double = map["longitude"].value() else {
+            return nil
+        }
+        self.init()
+    }
+    
+    public convenience init(latitude: CLLocationDegrees, longitude: CLLocationDegrees) {
+        self.init()
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+    
+    public convenience init(coordinate: CLLocationCoordinate2D) {
+        self.init(latitude: coordinate.latitude, longitude: coordinate.longitude)
+    }
+    
+    public convenience init(location: CLLocation) {
+        self.init(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)
+    }
+    
+    public convenience init(_ array: [CLLocationDegrees]) {
+        self.init(latitude: array[1], longitude: array[0])
+    }
+    
+    public func mapping(map: Map) {
+        latitude <- map["latitude"]
+        longitude <- map["longitude"]
+    }
+    
+}
+
+class GeoPointTransform: TransformOf<GeoPoint, [CLLocationDegrees]> {
+    
+    init() {
+        super.init(fromJSON: { (array) -> GeoPoint? in
+            if let array = array, array.count == 2 {
+                return GeoPoint(array)
+            }
+            return nil
+        }, toJSON: { (geopoint) -> [CLLocationDegrees]? in
+            if let geopoint = geopoint {
+                return [geopoint.longitude, geopoint.latitude]
+            }
+            return nil
+        })
+    }
+    
+}
+
+/// Override operator used during the `propertyMapping(_:)` method.
+public func <- (left: inout GeoPoint, right: (String, Map)) {
+    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    left <- (right.1, GeoPointTransform())
+}
+
+/// Override operator used during the `propertyMapping(_:)` method.
+public func <- (left: inout GeoPoint?, right: (String, Map)) {
+    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    left <- (right.1, GeoPointTransform())
+}
+
+/// Override operator used during the `propertyMapping(_:)` method.
+public func <- (left: inout GeoPoint!, right: (String, Map)) {
+    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    left <- (right.1, GeoPointTransform())
+}
+
+func ==(lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Bool {
+    return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude
+}
+
+extension CLLocation {
+    
+    public convenience init(geoPoint: GeoPoint) {
+        self.init(latitude: geoPoint.latitude, longitude: geoPoint.longitude)
+    }
+    
+}
+
+extension CLLocationCoordinate2D {
+    
+    public init(geoPoint: GeoPoint) {
+        self.init(latitude: geoPoint.latitude, longitude: geoPoint.longitude)
+    }
+    
+}

--- a/Kinvey/Kinvey/Geolocation.swift
+++ b/Kinvey/Kinvey/Geolocation.swift
@@ -34,11 +34,7 @@ open class GeoPoint: Object, Mappable {
         self.init(latitude: coordinate.latitude, longitude: coordinate.longitude)
     }
     
-    public convenience init(location: CLLocation) {
-        self.init(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)
-    }
-    
-    public convenience init(_ array: [CLLocationDegrees]) {
+    convenience init(_ array: [CLLocationDegrees]) {
         self.init(latitude: array[1], longitude: array[0])
     }
     

--- a/Kinvey/Kinvey/HttpRequestFactory.swift
+++ b/Kinvey/Kinvey/HttpRequestFactory.swift
@@ -153,7 +153,7 @@ class HttpRequestFactory: RequestFactory {
     
     func buildAppDataSave<T: Persistable>(_ persistable: T) -> HttpRequest {
         let collectionName = T.collectionName()
-        var bodyObject = Mapper<T>().toJSON(persistable)
+        var bodyObject = persistable.toJSON()
         let objId = bodyObject[PersistableIdKey] as? String
         let isNewObj = objId == nil || objId!.hasPrefix(ObjectIdTmpPrefix)
         let request = HttpRequest(

--- a/Kinvey/Kinvey/Metadata.swift
+++ b/Kinvey/Kinvey/Metadata.swift
@@ -61,7 +61,7 @@ public class Metadata: Object, Mappable {
     }
     
     /// Authentication Token.
-    open internal(set) var authtoken: String?
+    open internal(set) dynamic var authtoken: String?
     
     /// Constructor that validates if the map can be build a new instance of Metadata.
     public required init?(map: Map) {

--- a/Kinvey/KinveyTests/Person.swift
+++ b/Kinvey/KinveyTests/Person.swift
@@ -8,13 +8,14 @@
 
 @testable import Kinvey
 import ObjectMapper
+import CoreLocation
 
 class Person: Entity {
     
     dynamic var personId: String?
     dynamic var name: String?
     dynamic var age: Int = 0
-    
+    dynamic var geolocation: GeoPoint?
     dynamic var address: Address?
     
     override class func collectionName() -> String {
@@ -25,9 +26,10 @@ class Person: Entity {
         super.propertyMapping(map)
         
         personId <- ("personId", map[PersistableIdKey])
-        name <- map["name"]
-        age <- map["age"]
+        name <- ("name", map["name"])
+        age <- ("age", map["age"])
         address <- ("address", map["address"], AddressTransform())
+        geolocation <- ("geolocation", map["geolocation"])
     }
     
 }

--- a/Kinvey/KinveyTests/QueryTest.swift
+++ b/Kinvey/KinveyTests/QueryTest.swift
@@ -163,4 +163,82 @@ class QueryTest: XCTestCase {
         XCTAssertEqual(encodeQuery(Query { $0.predicate = NSPredicate(format: "lastName == %@", "Barros"); $0.sortDescriptors = [NSSortDescriptor(key: "age", ascending: false)]; $0.skip = 2; $0.limit = 5 }), "query=\(encodeURL(["lastName" : "Barros"]))&limit=5&skip=2&sort=\(encodeURL(["age" : -1]))")
     }
     
+    func testPredicateBetween() {
+        let result = encodeQuery(Query(format: "expenses BETWEEN %@", [200, 400]))
+        let json = [
+            "$and" : [
+                ["expenses" : ["$gte" : 200]],
+                ["expenses" : ["$lte" : 400]]
+            ]
+        ]
+        let expected = "query=\(encodeURL(json))"
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testPredicateContains() {
+        let result = encodeQuery(Query(format: "name CONTAINS[c] %@", "f"))
+        let json = [
+            "name" : [
+                "$regex" : ".*f.*"
+            ]
+        ]
+        let expected = "query=\(encodeURL(json))"
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testPredicateEndsWith() {
+        let result = encodeQuery(Query(format: "name ENDSWITH %@", "m"))
+        let json = [
+            "name" : [
+                "$regex" : ".*m"
+            ]
+        ]
+        let expected = "query=\(encodeURL(json))"
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testPredicateLike() {
+        let result = encodeQuery(Query(format: "name LIKE %@", "*m*"))
+        let json = [
+            "name" : [
+                "$regex" : "/(*m*)/"
+            ]
+        ]
+        let expected = "query=\(encodeURL(json))"
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testPredicateCount() {
+        var result = encodeQuery(Query(format: "names.@count == %@", 2))
+        let json = [
+            "names" : [
+                "$size" : 2
+            ]
+        ]
+        let expected = "query=\(encodeURL(json))"
+        XCTAssertEqual(result, expected)
+        
+        result = encodeQuery(Query(format: "%@ = names.@count", 2))
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testPredicateDate() {
+        let date = Date()
+        let result = encodeQuery(Query(format: "date == %@", date))
+        let json = [
+            "date" : date.timeIntervalSince1970
+        ]
+        let expected = "query=\(encodeURL(json))"
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testPredicateNil() {
+        let result = encodeQuery(Query(format: "date == %@", NSNull()))
+        let json = [
+            "date" : NSNull()
+        ]
+        let expected = "query=\(encodeURL(json))"
+        XCTAssertEqual(result, expected)
+    }
+    
 }


### PR DESCRIPTION
#### Description

Solves the problem of perform geolocation queries in the backend and locally

#### Changes

- NSPredicate -> MongoDB adaptor
- Local cache

#### Tests

- Test geolocation queries with circles with a radio
- Test geolocation queries with polygons (which includes the use case of boxes / rectangles)