### PR TITLE
MLIBZ-1667: WIP fixed file json mapping

### DIFF
--- a/Kinvey/Kinvey.xcodeproj/project.pbxproj
+++ b/Kinvey/Kinvey.xcodeproj/project.pbxproj
@@ -88,7 +88,6 @@
 		5781D1311CE3ADBC00369F40 /* ErrorTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5781D1301CE3ADBC00369F40 /* ErrorTestCase.swift */; };
 		5781D1341CE3B0FB00369F40 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5781D12E1CE3ACA000369F40 /* Localizable.strings */; };
 		5781D1361CE3D0BA00369F40 /* FileTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5781D1351CE3D0BA00369F40 /* FileTestCase.swift */; };
-		5781D1381CE3D61B00369F40 /* Caminandes 3 - TRAILER.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 5781D1371CE3D61B00369F40 /* Caminandes 3 - TRAILER.mp4 */; };
 		5783B5071C1910B00077F8A6 /* JsonObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5783B5061C1910B00077F8A6 /* JsonObject.swift */; };
 		57873DEC1DFF3FDC002C87BF /* PushTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57873DEB1DFF3FDC002C87BF /* PushTestCase.swift */; };
 		57873E071DFFD983002C87BF /* KIF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578F5C921C99EED100B20F17 /* KIF.swift */; };
@@ -96,7 +95,6 @@
 		57873E121DFFD983002C87BF /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57BEAE2C1C98805600479206 /* CoreGraphics.framework */; };
 		57873E131DFFD983002C87BF /* Kinvey.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57A27C811C178F17000DF951 /* Kinvey.framework */; };
 		57873E141DFFD983002C87BF /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57B0C1DC1CDCE88900492D6C /* RealmSwift.framework */; };
-		57873E161DFFD983002C87BF /* Caminandes 3 - TRAILER.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 5781D1371CE3D61B00369F40 /* Caminandes 3 - TRAILER.mp4 */; };
 		57873E171DFFD983002C87BF /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57A2ED951C4D5F74006D26A9 /* Media.xcassets */; };
 		57873E191DFFD983002C87BF /* Kinvey.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 57A27C811C178F17000DF951 /* Kinvey.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		57873E1A1DFFD983002C87BF /* KIF.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 57B0C1D21CDCE88900492D6C /* KIF.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -145,7 +143,6 @@
 		5793B88D1D2306A60088B5F9 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57BEAE2C1C98805600479206 /* CoreGraphics.framework */; };
 		5793B88E1D2306A60088B5F9 /* Kinvey.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57A27C811C178F17000DF951 /* Kinvey.framework */; };
 		5793B88F1D2306A60088B5F9 /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57B0C1DC1CDCE88900492D6C /* RealmSwift.framework */; };
-		5793B8911D2306A60088B5F9 /* Caminandes 3 - TRAILER.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 5781D1371CE3D61B00369F40 /* Caminandes 3 - TRAILER.mp4 */; };
 		5793B8921D2306A60088B5F9 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57A2ED951C4D5F74006D26A9 /* Media.xcassets */; };
 		5793B8941D2306A60088B5F9 /* Kinvey.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 57A27C811C178F17000DF951 /* Kinvey.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5793B89B1D2307220088B5F9 /* StoreTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5706FEC21C1F9A6D0037E7D0 /* StoreTestCase.swift */; };
@@ -236,7 +233,6 @@
 		57E447F81DF62DC7003D1AFA /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57BEAE2C1C98805600479206 /* CoreGraphics.framework */; };
 		57E447F91DF62DC7003D1AFA /* Kinvey.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57A27C811C178F17000DF951 /* Kinvey.framework */; };
 		57E447FA1DF62DC7003D1AFA /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57B0C1DC1CDCE88900492D6C /* RealmSwift.framework */; };
-		57E447FC1DF62DC7003D1AFA /* Caminandes 3 - TRAILER.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 5781D1371CE3D61B00369F40 /* Caminandes 3 - TRAILER.mp4 */; };
 		57E447FD1DF62DC7003D1AFA /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57A2ED951C4D5F74006D26A9 /* Media.xcassets */; };
 		57E447FF1DF62DC7003D1AFA /* Kinvey.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 57A27C811C178F17000DF951 /* Kinvey.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		57E448061DF62E05003D1AFA /* NoCacheTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795AB011DD136B8001FC808 /* NoCacheTestCase.swift */; };
@@ -602,7 +598,6 @@
 		5781D12E1CE3ACA000369F40 /* Localizable.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 		5781D1301CE3ADBC00369F40 /* ErrorTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorTestCase.swift; sourceTree = "<group>"; };
 		5781D1351CE3D0BA00369F40 /* FileTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileTestCase.swift; sourceTree = "<group>"; };
-		5781D1371CE3D61B00369F40 /* Caminandes 3 - TRAILER.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Caminandes 3 - TRAILER.mp4"; sourceTree = "<group>"; };
 		5783B5061C1910B00077F8A6 /* JsonObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JsonObject.swift; sourceTree = "<group>"; };
 		5783B6661C1A13CB0077F8A6 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		57873DEB1DFF3FDC002C87BF /* PushTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushTestCase.swift; sourceTree = "<group>"; };
@@ -1095,7 +1090,6 @@
 		57A27C8F1C178F18000DF951 /* KinveyTests */ = {
 			isa = PBXGroup;
 			children = (
-				5781D1371CE3D61B00369F40 /* Caminandes 3 - TRAILER.mp4 */,
 				57A960A21CC6D729005E52A8 /* Models */,
 				57A27C921C178F18000DF951 /* Info.plist */,
 				5765B83C1C972D7000080FFA /* URLProtocols.swift */,
@@ -1662,7 +1656,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				57873E161DFFD983002C87BF /* Caminandes 3 - TRAILER.mp4 in Resources */,
 				57873E171DFFD983002C87BF /* Media.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1706,7 +1699,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5793B8911D2306A60088B5F9 /* Caminandes 3 - TRAILER.mp4 in Resources */,
 				5793B8921D2306A60088B5F9 /* Media.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1723,7 +1715,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5781D1381CE3D61B00369F40 /* Caminandes 3 - TRAILER.mp4 in Resources */,
 				57A2ED961C4D5F74006D26A9 /* Media.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1755,7 +1746,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				57E447FC1DF62DC7003D1AFA /* Caminandes 3 - TRAILER.mp4 in Resources */,
 				57E447FD1DF62DC7003D1AFA /* Media.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Kinvey/Kinvey/Acl.swift
+++ b/Kinvey/Kinvey/Acl.swift
@@ -36,7 +36,7 @@ class AclTransformType: TransformType {
         }
         return nil
     }
-
+    
 }
 
 /// This class represents the ACL (Access Control List) for a record.
@@ -152,11 +152,11 @@ public final class Acl: Object, Mappable, BuilderType {
     
     /// This function is where all variable mappings should occur. It is executed by Mapper during the mapping (serialization and deserialization) process.
     open func mapping(map: Map) {
-        creator <- map[Acl.CreatorKey]
-        globalRead.value <- map[Acl.GlobalReadKey]
-        globalWrite.value <- map[Acl.GlobalWriteKey]
-        readers <- (map[Acl.ReadersKey], AclTransformType())
-        writers <- (map[Acl.WritersKey], AclTransformType())
+        creator <- ("creator", map[Acl.CreatorKey])
+        globalRead.value <- ("globalRead", map[Acl.GlobalReadKey])
+        globalWrite.value <- ("globalWrite", map[Acl.GlobalWriteKey])
+        readers <- ("readers", map[Acl.ReadersKey])
+        writers <- ("writers", map[Acl.WritersKey])
     }
     
     /**

--- a/Kinvey/Kinvey/HttpRequestFactory.swift
+++ b/Kinvey/Kinvey/HttpRequestFactory.swift
@@ -235,26 +235,12 @@ class HttpRequestFactory: RequestFactory {
             client: client
         )
         
-        var bodyObject: [String : Any] = [
-            "_public" : file.publicAccessible as AnyObject
-        ]
-        
-        if let fileId = file.fileId {
-            bodyObject["_id"] = fileId
-        }
-        
-        if let fileName = file.fileName {
-            bodyObject["_filename"] = fileName
-        }
-        
+        var bodyObject = file.toJSON()
+
         if let size = file.size.value {
             bodyObject["size"] = String(size)
         }
-        
-        if let mimeType = file.mimeType {
-            bodyObject["mimeType"] = mimeType
-        }
-        
+
         request.request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.request.setValue(file.mimeType ?? "application/octet-stream", forHTTPHeaderField: "X-Kinvey-Content-Type")
         request.request.httpBody = try! JSONSerialization.data(withJSONObject: bodyObject, options: [])

--- a/Kinvey/KinveyTests/AclTestCase.swift
+++ b/Kinvey/KinveyTests/AclTestCase.swift
@@ -312,7 +312,7 @@ class AclTestCase: StoreTestCase {
                     "name" : "Victor",
                     "age" : 29,
                     "_acl" : [
-                        "r" : "[\"\(user.userId)\"]",
+                        "r" : ["\(user.userId)"],
                         "creator" : sharedClient.activeUser!.userId
                     ],
                     "_kmd" : [
@@ -377,7 +377,7 @@ class AclTestCase: StoreTestCase {
                     "name" : "Victor",
                     "age" : 29,
                     "_acl" : [
-                        "w" : "[\"\(user.userId)\"]",
+                        "w" : ["\(user.userId)"],
                         "creator" : UUID().uuidString
                     ],
                     "_kmd" : [

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -406,8 +406,6 @@ class UserTests: KinveyTestCase {
                 waitForExpectations(timeout: defaultTimeout) { error in
                     expectationUserLookup = nil
                 }
-                
-                client.logNetworkEnabled = false
             }
         }
     }


### PR DESCRIPTION
#### Description
Fixes MLIBZ-1667 - the ACL properties set on a file object are not being POSTed to the backend.

#### Changes
* The `File` class now extends `Entity`. This allows us to define JSON mappings for it like other kinvey entities.
* All serialization and deserialization of `File` object is via JSON mapper.
* (Proposed) - since `Entity` maps `_id` already, is there any value to having a separate `fileId`? The proposal is to remove `fileId`, although that'll be a breaking change.
* (Proposed) - current file APIs pass the `File` object as a reference. In all of our other data APIs, we build new instances in response to `save` or `fetch` calls. Is there a reason to use `File` as references? The proposal is to treat `File` like any data object. The instance received in the completion block is a new object.

#### Tests
* Current unit tests pass with minor changes.