### PR TITLE
MLIBZ-1726: ignoring protocol properties

### DIFF
--- a/Kinvey/Kinvey/Entity.swift
+++ b/Kinvey/Kinvey/Entity.swift
@@ -93,16 +93,22 @@ open class Entity: Object, Persistable {
      */
     open override class func ignoredProperties() -> [String] {
         var properties = [String]()
-        for property in ObjCRuntime.properties(self) {
-            if !(ObjCRuntime.type(property.1, isSubtypeOf: NSDate.self) ||
-                ObjCRuntime.type(property.1, isSubtypeOf: NSData.self) ||
-                ObjCRuntime.type(property.1, isSubtypeOf: NSString.self) ||
-                ObjCRuntime.type(property.1, isSubtypeOf: RLMObjectBase.self) ||
-                ObjCRuntime.type(property.1, isSubtypeOf: RLMOptionalBase.self) ||
-                ObjCRuntime.type(property.1, isSubtypeOf: RLMListBase.self) ||
-                ObjCRuntime.type(property.1, isSubtypeOf: RLMCollection.self))
+        for (propertyName, (type, subType)) in ObjCRuntime.properties(forClass: self) {
+            if let type = type,
+                let typeClass = NSClassFromString(type),
+                !(ObjCRuntime.type(typeClass, isSubtypeOf: NSDate.self) ||
+                ObjCRuntime.type(typeClass, isSubtypeOf: NSData.self) ||
+                ObjCRuntime.type(typeClass, isSubtypeOf: NSString.self) ||
+                ObjCRuntime.type(typeClass, isSubtypeOf: RLMObjectBase.self) ||
+                ObjCRuntime.type(typeClass, isSubtypeOf: RLMOptionalBase.self) ||
+                ObjCRuntime.type(typeClass, isSubtypeOf: RLMListBase.self) ||
+                ObjCRuntime.type(typeClass, isSubtypeOf: RLMCollection.self))
             {
-                properties.append(property.0)
+                properties.append(propertyName)
+            } else if let subType = subType,
+                let _ = NSProtocolFromString(subType)
+            {
+                properties.append(propertyName)
             }
         }
         return properties

--- a/Kinvey/Kinvey/ObjCRuntime.swift
+++ b/Kinvey/Kinvey/ObjCRuntime.swift
@@ -83,33 +83,39 @@ internal class ObjCRuntime: NSObject {
         return nil
     }
     
-    internal class func properties(_ cls: AnyClass) -> [String : AnyClass] {
-        let regexClassName = try! NSRegularExpression(pattern: "@\"(\\w+)(?:<(\\w+)>)?\"", options: [])
+    /// Returns the properties of a class and their types and subtypes, if exists
+    internal class func properties(forClass cls: AnyClass) -> [String : (String?, String?)] {
+        let regexClassName = try! NSRegularExpression(pattern: "@\"(\\w+)?(?:<(\\w+)>)?\"", options: [])
         var cls: AnyClass? = cls
-        var results = [String : AnyClass]()
+        var results = [String : (String?, String?)]()
         while cls != nil {
             var propertyCount = UInt32(0)
-            let properties = class_copyPropertyList(cls, &propertyCount)
+            guard let properties = class_copyPropertyList(cls, &propertyCount) else { break }
             defer { free(properties) }
             for i in UInt32(0) ..< propertyCount {
-                let property = properties?[Int(i)]
+                guard let property = properties[Int(i)] else { break }
                 if let propertyName = String(validatingUTF8: property_getName(property))
                 {
                     var attributeCount = UInt32(0)
-                    let attributes = property_copyAttributeList(property, &attributeCount)
+                    guard let attributes = property_copyAttributeList(property, &attributeCount) else { break }
                     defer { free(attributes) }
                     for x in UInt32(0) ..< attributeCount {
-                        let attribute = attributes?[Int(x)]
-                        if let attributeName = String(validatingUTF8: (attribute?.name)!) , attributeName == "T",
-                            let attributeValue = String(validatingUTF8: (attribute?.value)!),
-                            let textCheckingResult = regexClassName.matches(in: attributeValue, options: [], range: NSMakeRange(0, attributeValue.characters.count)).first
+                        let attribute = attributes[Int(x)]
+                        if let attributeName = String(validatingUTF8: attribute.name),
+                            attributeName == "T",
+                            let attributeValue = String(validatingUTF8: attribute.value),
+                            let textCheckingResult = regexClassName.matches(in: attributeValue, range: NSMakeRange(0, attributeValue.characters.count)).first
                         {
-                            let attributeValueNSString = attributeValue as NSString
-                            let propertyTypeName = attributeValueNSString.substring(with: textCheckingResult.rangeAt(1))
-                            if let propertyTypeNameClass = NSClassFromString(propertyTypeName) {
-                                results[propertyName] = propertyTypeNameClass
-                                break
+                            var tuple: (type: String?, subType: String?) = (nil, nil)
+                            if let range = textCheckingResult.rangeAt(1).toRange() {
+                                tuple.type = attributeValue.substring(with: range)
                             }
+                            
+                            if textCheckingResult.numberOfRanges > 1,
+                                let range = textCheckingResult.rangeAt(2).toRange() {
+                                tuple.subType = attributeValue.substring(with: range)
+                            }
+                            results[propertyName] = tuple
                         }
                     }
                 }

--- a/Kinvey/Kinvey/String.swift
+++ b/Kinvey/Kinvey/String.swift
@@ -21,6 +21,12 @@ extension String {
         }
     }
     
+    func substring(with rangeInt: Range<Int>) -> String {
+        let startIndex = index(self.startIndex, offsetBy: rangeInt.lowerBound)
+        let endIndex = index(self.startIndex, offsetBy: rangeInt.upperBound)
+        return self[startIndex..<endIndex]
+    }
+    
 }
 
 extension NSString {

--- a/Kinvey/KinveyTests/Person.swift
+++ b/Kinvey/KinveyTests/Person.swift
@@ -10,6 +10,26 @@
 import ObjectMapper
 import CoreLocation
 
+protocol PersonDelegate {
+}
+
+@objc
+protocol PersonObjCDelegate {
+}
+
+struct PersonStruct {
+    var test: String
+}
+
+enum PersonEnum {
+    case test
+}
+
+@objc
+enum PersonObjCEnum: Int {
+    case test
+}
+
 class Person: Entity {
     
     dynamic var personId: String?
@@ -17,6 +37,14 @@ class Person: Entity {
     dynamic var age: Int = 0
     dynamic var geolocation: GeoPoint?
     dynamic var address: Address?
+    
+    //testing properties that must be ignored
+    var personDelegate: PersonDelegate?
+    var personObjCDelegate: PersonObjCDelegate?
+    weak var weakPersonObjCDelegate: PersonObjCDelegate?
+    var personStruct: PersonStruct?
+    var personEnum: PersonEnum?
+    var personObjCEnum: PersonObjCEnum?
     
     override class func collectionName() -> String {
         return "Person"


### PR DESCRIPTION
#### Description

Handling cases where protocols are @objc compatible

#### Changes

* Now our `Entity` base class ignore protocols that are @objc compatible

#### Tests

* Adding a `wear var delegate: Protocol?` to test if the unit tests will crash