### PR TITLE
MLIBZ-1713: throwing a proper error if the push configuration is missing in the backend

### DIFF
--- a/Kinvey/Kinvey.xcodeproj/project.pbxproj
+++ b/Kinvey/Kinvey.xcodeproj/project.pbxproj
@@ -2764,6 +2764,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/KinveyApp.app/KinveyApp";
 			};
 			name = Debug;
@@ -2784,6 +2785,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinvey.KinveyAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/KinveyApp.app/KinveyApp";
 			};
 			name = Release;

--- a/Kinvey/Kinvey/Error.swift
+++ b/Kinvey/Kinvey/Error.swift
@@ -26,6 +26,9 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
     /// Error when a Data Link endpoint is not found, usually when you are using a Data Link Connector (DLC).
     case dataLinkEntityNotFound(httpResponse: HTTPURLResponse?, data: Data?, debug: String, description: String)
     
+    /// Error when there's a missing configuration in the backend.
+    case missingConfiguration(httpResponse: HTTPURLResponse?, data: Data?, debug: String, description: String)
+    
     /// Error when the type is unknow.
     case unknownError(httpResponse: HTTPURLResponse?, data: Data?, error: String)
     
@@ -65,7 +68,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
              .dataLinkEntityNotFound(_, _, _, let description),
              .unknownError(_, _, let description),
              .unauthorized(_, _, _, let description),
-             .invalidOperation(let description):
+             .invalidOperation(let description),
+             .missingConfiguration(_, _, _, let description):
             return description
         case .objectIdMissing:
             return NSLocalizedString("Error.objectIdMissing", bundle: bundle, comment: "")
@@ -97,7 +101,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
     public var debugDescription: String {
         switch self {
         case .methodNotAllowed(_, _, let debug, _),
-             .dataLinkEntityNotFound(_, _, let debug, _):
+             .dataLinkEntityNotFound(_, _, let debug, _),
+             .missingConfiguration(_, _, let debug, _):
             return debug
         default:
             return description
@@ -132,7 +137,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
              .dataLinkEntityNotFound(_, let data, _, _),
              .methodNotAllowed(_, let data, _, _),
              .unauthorized(_, let data, _, _),
-             .invalidResponse(_, let data):
+             .invalidResponse(_, let data),
+             .missingConfiguration(_, let data, _, _):
             return data
         default:
             return nil

--- a/Kinvey/Kinvey/HttpResponse.swift
+++ b/Kinvey/Kinvey/HttpResponse.swift
@@ -31,39 +31,31 @@ struct HttpResponse: Response {
     }
     
     var isOK: Bool {
-        get {
-            return 200 <= response.statusCode && response.statusCode < 300
-        }
+        return 200 <= response.statusCode && response.statusCode < 300
     }
     
     var isNotModified: Bool {
-        get {
-            return response.statusCode == 304
-        }
+        return response.statusCode == 304
     }
     
     var isUnauthorized: Bool {
-        get {
-            return response.statusCode == 401
-        }
+        return response.statusCode == 401
+    }
+    
+    var isForbidden: Bool {
+        return response.statusCode == 403
     }
     
     var isNotFound: Bool {
-        get {
-            return response.statusCode == 404
-        }
+        return response.statusCode == 404
     }
     
     var isMethodNotAllowed: Bool {
-        get {
-            return response.statusCode == 405
-        }
+        return response.statusCode == 405
     }
     
     var etag: String? {
-        get {
-            return response.allHeaderFields["Etag"] as? String
-        }
+        return response.allHeaderFields["Etag"] as? String
     }
 
 }

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -82,10 +82,19 @@ func buildError(_ data: Data?, _ response: Response?, _ error: Swift.Error?, _ c
         let json = client.responseParser.parse(data) as? [String : String]
     {
         return Error.buildUnauthorized(httpResponse: response.httpResponse, data: data, json: json)
-    } else if let response = response , response.isMethodNotAllowed, let json = client.responseParser.parse(data) as? [String : String] , json["error"] == "MethodNotAllowed" {
+    } else if let response = response, response.isMethodNotAllowed, let json = client.responseParser.parse(data) as? [String : String] , json["error"] == "MethodNotAllowed" {
         return Error.buildMethodNotAllowed(httpResponse: response.httpResponse, data: data, json: json)
-    } else if let response = response , response.isNotFound, let json = client.responseParser.parse(data) as? [String : String] , json["error"] == "DataLinkEntityNotFound" {
+    } else if let response = response, response.isNotFound, let json = client.responseParser.parse(data) as? [String : String] , json["error"] == "DataLinkEntityNotFound" {
         return Error.buildDataLinkEntityNotFound(httpResponse: response.httpResponse, data: data, json: json)
+    } else if let response = response,
+        response.isForbidden,
+        let json = client.responseParser.parse(data) as? [String : String],
+        let error = json["error"],
+        error == "MissingConfiguration",
+        let debug = json["debug"],
+        let description = json["description"]
+    {
+        return Error.missingConfiguration(httpResponse: response.httpResponse, data: data, debug: debug, description: description)
     } else if let response = response, let json = client.responseParser.parse(data) {
         return Error.buildUnknownJsonError(httpResponse: response.httpResponse, data: data, json: json)
     } else {

--- a/Kinvey/Kinvey/LocalResponse.swift
+++ b/Kinvey/Kinvey/LocalResponse.swift
@@ -13,6 +13,7 @@ class LocalResponse: Response {
     var isOK = true
     var isUnauthorized = false
     var isNotModified = false
+    var isForbidden = false
     var isNotFound = false
     var isMethodNotAllowed = false
     

--- a/Kinvey/Kinvey/Response.swift
+++ b/Kinvey/Kinvey/Response.swift
@@ -13,6 +13,7 @@ internal protocol Response {
     var isOK: Bool { get }
     var isNotModified: Bool { get }
     var isUnauthorized: Bool { get }
+    var isForbidden: Bool { get }
     var isNotFound: Bool { get }
     var isMethodNotAllowed: Bool { get }
     

--- a/Kinvey/KinveyApp/AppDelegate.swift
+++ b/Kinvey/KinveyApp/AppDelegate.swift
@@ -23,7 +23,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let appKey = ProcessInfo.processInfo.environment["KINVEY_APP_KEY"],
             let appSecret = ProcessInfo.processInfo.environment["KINVEY_APP_SECRET"]
         {
-            Kinvey.sharedClient.initialize(appKey: appKey, appSecret: appSecret)
+            Kinvey.sharedClient.initialize(appKey: appKey, appSecret: appSecret) { user, error in
+                if let user = user {
+                    print("user: \(user)")
+                }
+            }
+        }
+        
+        if #available(iOS 10.0, *) {
+            Kinvey.sharedClient.push.registerForNotifications { (succeed, error) in
+                print("succeed: \(succeed)")
+                if let error = error {
+                    print("error: \(error)")
+                }
+            }
+        } else {
+            Kinvey.sharedClient.push.registerForPush { (succeed, error) in
+                print("succeed: \(succeed)")
+                if let error = error {
+                    print("error: \(error)")
+                }
+            }
         }
         
         return true

--- a/Kinvey/KinveyTests/PushTestCase.swift
+++ b/Kinvey/KinveyTests/PushTestCase.swift
@@ -76,6 +76,62 @@ class PushTestCase: KinveyTestCase {
         }
     }
     
+    func testMissingConfigurationError() {
+        signUp()
+        
+        do {
+            if useMockData {
+                mockResponse(statusCode: 403, json: [
+                    "error" : "MissingConfiguration",
+                    "description" : "This feature is not properly configured for this app backend. Please configure it through the console first, or contact support for more information.",
+                    "debug" : "Push notifications for iOS are not properly configured for this app backend. Please enable push notifications through the console first."
+                ])
+            }
+            defer {
+                if useMockData {
+                    setURLProtocol(nil)
+                }
+            }
+            
+            weak var expectaionRegister = expectation(description: "Register")
+            
+            Kinvey.sharedClient.push.registerForNotifications { result, error in
+                XCTAssertFalse(result)
+                XCTAssertNotNil(error)
+                
+                if let error = error {
+                    XCTAssertTrue(error is Kinvey.Error)
+                    if let error = error as? Kinvey.Error {
+                        switch error {
+                        case .missingConfiguration(let httpResponse, _, let debug, let description):
+                            XCTAssertEqual(httpResponse?.statusCode, 403)
+                            XCTAssertEqual(debug, "Push notifications for iOS are not properly configured for this app backend. Please enable push notifications through the console first.")
+                            XCTAssertEqual(description, "This feature is not properly configured for this app backend. Please configure it through the console first, or contact support for more information.")
+                        default:
+                            XCTFail()
+                        }
+                    }
+                }
+                
+                expectaionRegister?.fulfill()
+            }
+            
+            #if (arch(i386) || arch(x86_64)) && os(iOS)
+                tester().acknowledgeSystemAlert()
+                
+                DispatchQueue.main.async {
+                    let app = UIApplication.shared
+                    let data = UUID().uuidString.data(using: .utf8)!
+                    app.delegate!.application!(app, didRegisterForRemoteNotificationsWithDeviceToken: data)
+                }
+            #endif
+            
+            waitForExpectations(timeout: defaultTimeout) { error in
+                expectaionRegister = nil
+            }
+        }
+    }
+    
     func testBadgeNumber() {
         UIApplication.shared.applicationIconBadgeNumber = 1
         


### PR DESCRIPTION
#### Description

Missing APNS push configuration in the console should return an error

#### Changes

* Building the right proper error

#### Tests

* Unit test mocking an error response from the backend
