### PR TITLE
MLIBZ-1660: Local query should not crash if field not found on entity

### DIFF
--- a/Kinvey/Kinvey/Kinvey.h
+++ b/Kinvey/Kinvey/Kinvey.h
@@ -13,3 +13,13 @@ FOUNDATION_EXPORT double KinveyVersionNumber;
 
 //! Project version string for Kinvey.
 FOUNDATION_EXPORT const unsigned char KinveyVersionString[];
+
+NS_INLINE NSException * _Nullable tryBlock(void(^_Nonnull tryBlock)(void)) {
+    @try {
+        tryBlock();
+    }
+    @catch (NSException *exception) {
+        return exception;
+    }
+    return nil;
+}

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -1342,4 +1342,23 @@ class SyncStoreTests: StoreTestCase {
         
     }
     
+    func testQueryWithPropertyNotMapped() {
+        let query = Query(format: "propertyNotMapped == %@", 10)
+        
+        weak var expectationFind = expectation(description: "Find")
+        
+        store.find(query) { persons, error in
+            XCTAssertNotNil(persons)
+            XCTAssertNil(error)
+            
+            XCTAssertEqual(persons?.count, 0)
+            
+            expectationFind?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { error in
+            expectationFind = nil
+        }
+    }
+    
 }


### PR DESCRIPTION
#### Description

Local query should not crash if a field is not mapped in the entity class

#### Changes

* Make the local cache ignore `Invalid property name` errors

#### Tests

* Unit Test runs a local query with a non-mapped field
