### PR TITLE
MLIBZ-1723: making push operations able to run in parallel

### DIFF
--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -230,7 +230,7 @@ open class DataStore<T: Persistable> where T: NSObject {
             log.error("Object Id is missing")
             throw Error.objectIdMissing
         }
-        return removeById(id, writePolicy:writePolicy, completionHandler: completionHandler)
+        return remove(byId: id, writePolicy:writePolicy, completionHandler: completionHandler)
     }
     
     /// Deletes a list of records.
@@ -242,12 +242,18 @@ open class DataStore<T: Persistable> where T: NSObject {
                 ids.append(id)
             }
         }
-        return removeById(ids, writePolicy:writePolicy, completionHandler: completionHandler)
+        return remove(byIds: ids, writePolicy:writePolicy, completionHandler: completionHandler)
     }
     
     /// Deletes a record using the `_id` of the record.
     @discardableResult
+    @available(*, deprecated: 3.4.0, message: "Please use `remove(byId:)` instead")
     open func removeById(_ id: String, writePolicy: WritePolicy? = nil, completionHandler: IntCompletionHandler?) -> Request {
+        return remove(byId: id, writePolicy: writePolicy, completionHandler: completionHandler)
+    }
+    
+    @discardableResult
+    open func remove(byId id: String, writePolicy: WritePolicy? = nil, completionHandler: IntCompletionHandler?) -> Request {
         validate(id: id)
 
         let writePolicy = writePolicy ?? self.writePolicy
@@ -258,7 +264,13 @@ open class DataStore<T: Persistable> where T: NSObject {
     
     /// Deletes a list of records using the `_id` of the records.
     @discardableResult
+    @available(*, deprecated: 3.4.0, message: "Please use `remove(byIds:)` instead")
     open func removeById(_ ids: [String], writePolicy: WritePolicy? = nil, completionHandler: IntCompletionHandler?) -> Request {
+        return remove(byIds: ids, writePolicy: writePolicy, completionHandler: completionHandler)
+    }
+    
+    @discardableResult
+    open func remove(byIds ids: [String], writePolicy: WritePolicy? = nil, completionHandler: IntCompletionHandler?) -> Request {
         if ids.isEmpty {
             let message = "ids cannot be an empty array"
             log.severe(message)

--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -252,6 +252,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         return remove(byId: id, writePolicy: writePolicy, completionHandler: completionHandler)
     }
     
+    /// Deletes a record using the `_id` of the record.
     @discardableResult
     open func remove(byId id: String, writePolicy: WritePolicy? = nil, completionHandler: IntCompletionHandler?) -> Request {
         validate(id: id)
@@ -269,6 +270,7 @@ open class DataStore<T: Persistable> where T: NSObject {
         return remove(byIds: ids, writePolicy: writePolicy, completionHandler: completionHandler)
     }
     
+    /// Deletes a list of records using the `_id` of the records.
     @discardableResult
     open func remove(byIds ids: [String], writePolicy: WritePolicy? = nil, completionHandler: IntCompletionHandler?) -> Request {
         if ids.isEmpty {

--- a/Kinvey/Kinvey/Endpoint.swift
+++ b/Kinvey/Kinvey/Endpoint.swift
@@ -22,7 +22,7 @@ internal enum Endpoint {
     
     case appData(client: Client, collectionName: String)
     case appDataById(client: Client, collectionName: String, id: String)
-    case appDataByQuery(client: Client, collectionName: String, query: Query)
+    case appDataByQuery(client: Client, collectionName: String, query: Query?)
     case appDataCount(client: Client, collectionName: String, query: Query?)
     
     case pushRegisterDevice(client: Client)
@@ -69,7 +69,7 @@ internal enum Endpoint {
             return client.apiHostName.appendingPathComponent("/appdata/\(client.appKey!)/\(collectionName)/\(id)")
         case .appDataByQuery(let client, let collectionName, let query):
             let url = client.apiHostName.appendingPathComponent("/appdata/\(client.appKey!)/\(collectionName)/").absoluteString
-            if query.isEmpty {
+            guard let query = query else {
                 return URL(string: url)!
             }
             

--- a/Kinvey/Kinvey/HttpRequestFactory.swift
+++ b/Kinvey/Kinvey/HttpRequestFactory.swift
@@ -142,7 +142,7 @@ class HttpRequestFactory: RequestFactory {
     }
     
     func buildAppDataFindByQuery(collectionName: String, query: Query) -> HttpRequest {
-        let request = HttpRequest(endpoint: Endpoint.appDataByQuery(client: client, collectionName: collectionName, query: query), credential: client.activeUser, client: client)
+        let request = HttpRequest(endpoint: Endpoint.appDataByQuery(client: client, collectionName: collectionName, query: query.isEmpty ? nil : query), credential: client.activeUser, client: client)
         return request
     }
     

--- a/Kinvey/Kinvey/PendingOperation.swift
+++ b/Kinvey/Kinvey/PendingOperation.swift
@@ -10,6 +10,7 @@ import Foundation
 
 internal protocol PendingOperationType {
     
+    var collectionName: String { get }
     var objectId: String? { get }
     
     func buildRequest() -> URLRequest

--- a/Kinvey/Kinvey/PushOperation.swift
+++ b/Kinvey/Kinvey/PushOperation.swift
@@ -43,9 +43,6 @@ fileprivate class PushRequest: NSObject, Request {
     
     func addOperation(operation: Foundation.Operation) {
         dispatchSerialQueue.sync {
-            for dependencyOperation in self.completionOperation.dependencies {
-                operation.addDependency(dependencyOperation)
-            }
             self.completionOperation.addDependency(operation)
         }
     }

--- a/Kinvey/Kinvey/Query.swift
+++ b/Kinvey/Kinvey/Query.swift
@@ -112,7 +112,7 @@ public final class Query: NSObject, BuilderType, Mappable {
                 return queryStr.trimmingCharacters(in: CharacterSet.whitespaces)
             }
             
-            return nil
+            return "{}"
         }
     }
     

--- a/Kinvey/Kinvey/RealmCache.swift
+++ b/Kinvey/Kinvey/RealmCache.swift
@@ -614,6 +614,10 @@ class RealmPendingOperationThreadSafeReference: PendingOperationType {
         return realm.resolve(self.reference)!
     }()
     
+    var collectionName: String {
+        return realmPendingOperation.collectionName
+    }
+    
     var objectId: String? {
         return realmPendingOperation.objectId
     }

--- a/Kinvey/Kinvey/RealmSync.swift
+++ b/Kinvey/Kinvey/RealmSync.swift
@@ -56,6 +56,12 @@ class RealmSync<T: Persistable>: SyncType where T: NSObject {
         log.verbose("Saving pending operation: \(pendingOperation)")
         executor.executeAndWait {
             try! self.realm.write {
+                if !pendingOperation.collectionName.isEmpty,
+                    let objectId = pendingOperation.objectId
+                {
+                    let previousPendingOperations = self.realm.objects(RealmPendingOperation.self).filter("collectionName == %@ AND objectId == %@", pendingOperation.collectionName, objectId)
+                    self.realm.delete(previousPendingOperations)
+                }
                 self.realm.create(RealmPendingOperation.self, value: pendingOperation, update: true)
             }
         }

--- a/Kinvey/KinveyApp/AppDelegate.swift
+++ b/Kinvey/KinveyApp/AppDelegate.swift
@@ -30,21 +30,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
         
-        if #available(iOS 10.0, *) {
-            Kinvey.sharedClient.push.registerForNotifications { (succeed, error) in
-                print("succeed: \(succeed)")
-                if let error = error {
-                    print("error: \(error)")
-                }
-            }
-        } else {
-            Kinvey.sharedClient.push.registerForPush { (succeed, error) in
-                print("succeed: \(succeed)")
-                if let error = error {
-                    print("error: \(error)")
-                }
-            }
-        }
+//        if #available(iOS 10.0, *) {
+//            Kinvey.sharedClient.push.registerForNotifications { (succeed, error) in
+//                print("succeed: \(succeed)")
+//                if let error = error {
+//                    print("error: \(error)")
+//                }
+//            }
+//        } else {
+//            Kinvey.sharedClient.push.registerForPush { (succeed, error) in
+//                print("succeed: \(succeed)")
+//                if let error = error {
+//                    print("error: \(error)")
+//                }
+//            }
+//        }
         
         return true
     }


### PR DESCRIPTION
#### Description

Making push operations able to run in parallel
Performance tests jump from around `30s` to `5s` to push 100 records

#### Changes

* Not making pending operations depending each other so they can run in parallel

#### Tests

* Unit Test to make sure that only one pending operation is stored by entity