### PR TITLE
MLIBZ-1770: lookup custom user types

### DIFF
--- a/Kinvey/Kinvey/JsonResponseParser.swift
+++ b/Kinvey/Kinvey/JsonResponseParser.swift
@@ -51,32 +51,32 @@ class JsonResponseParser: ResponseParser {
         return nil
     }
     
-    fileprivate func parse<U: User>(_ json: JsonDictionary, userType: U.Type) -> U? {
+    fileprivate func parse<UserType: User>(_ json: JsonDictionary, userType: UserType.Type) -> UserType? {
         let map = Map(mappingType: .fromJSON, JSON: json)
-        let user = userType.init(map: map)
+        let user: UserType? = userType.init(map: map)
         user?.mapping(map: map)
         return user
     }
     
-    func parseUser(_ data: Data?) -> User? {
+    func parseUser<UserType: User>(_ data: Data?) -> UserType? {
         if let data = data , data.count > 0,
             let result = try? JSONSerialization.jsonObject(with: data) as? JsonDictionary,
             let json = result
         {
             let user = parse(json, userType: client.userType)
-            return user
+            return user as? UserType
         }
         return nil
     }
     
-    func parseUsers(_ data: Data?) -> [User]? {
+    func parseUsers<UserType: User>(_ data: Data?) -> [UserType]? {
         if let data = data , data.count > 0,
             let result = try? JSONSerialization.jsonObject(with: data) as? [JsonDictionary],
             let jsonArray = result
         {
-            var users = [User]()
+            var users = [UserType]()
             for json in jsonArray {
-                if let user = parse(json, userType: client.userType) {
+                if let user = parse(json, userType: client.userType) as? UserType {
                     users.append(user)
                 }
             }

--- a/Kinvey/Kinvey/ResponseParser.swift
+++ b/Kinvey/Kinvey/ResponseParser.swift
@@ -19,8 +19,8 @@ internal protocol ResponseParser {
     func parse<T: BaseMappable>(_ data: Data?) -> T?
     func parse<T: BaseMappable>(_ data: Data?) -> [T]?
     
-    func parseUser(_ data: Data?) -> User?
-    func parseUsers(_ data: Data?) -> [User]?
+    func parseUser<UserType: User>(_ data: Data?) -> UserType?
+    func parseUsers<UserType: User>(_ data: Data?) -> [UserType]?
 
 }
 

--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -431,7 +431,7 @@ open class User: NSObject, Credential, Mappable {
         let request = client.networkRequestFactory.buildUserLookup(user: self, userQuery: userQuery)
         Promise<[U]> { fulfill, reject in
             request.execute() { (data, response, error) in
-                if let response = response , response.isOK, let users: [U] = client.responseParser.parse(data) {
+                if let response = response, response.isOK, let users: [U] = client.responseParser.parseUsers(data) {
                     fulfill(users)
                 } else {
                     reject(buildError(data, response, error, client))


### PR DESCRIPTION
#### Description

Lookup Users are not returning the proper User type if a custom user type is being used.

#### Changes

* Make the user parse consider the custom user type set by the user

#### Tests

* Unit Test to cover the use case as described
