### PR TITLE
MLIBZ-1671: result enum

### DIFF
--- a/Kinvey/Kinvey.xcodeproj/project.pbxproj
+++ b/Kinvey/Kinvey.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 		57E7C7B31C51545900848748 /* ReadPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E7C7B21C51545900848748 /* ReadPolicy.swift */; };
 		57E7C7B51C51981400848748 /* RequestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E7C7B41C51981400848748 /* RequestType.swift */; };
 		57E7C7B71C519FD000848748 /* HttpHeaderCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E7C7B61C519FD000848748 /* HttpHeaderCredential.swift */; };
+		57F216AC1E9DA1640084AAF9 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F216AB1E9DA1640084AAF9 /* Result.swift */; };
 		57F91C261D6D15590012850A /* TaskProgressRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F91C251D6D15590012850A /* TaskProgressRequest.swift */; };
 		57F91C291D6E2C020012850A /* CountOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F91C281D6E2C020012850A /* CountOperation.swift */; };
 		57FB57D91C86581300AA590F /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FB57D81C86581300AA590F /* String.swift */; };
@@ -751,6 +752,7 @@
 		57E7C7B21C51545900848748 /* ReadPolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReadPolicy.swift; path = Kinvey/ReadPolicy.swift; sourceTree = SOURCE_ROOT; };
 		57E7C7B41C51981400848748 /* RequestType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestType.swift; sourceTree = "<group>"; };
 		57E7C7B61C519FD000848748 /* HttpHeaderCredential.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HttpHeaderCredential.swift; sourceTree = "<group>"; };
+		57F216AB1E9DA1640084AAF9 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		57F91C251D6D15590012850A /* TaskProgressRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskProgressRequest.swift; sourceTree = "<group>"; };
 		57F91C281D6E2C020012850A /* CountOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CountOperation.swift; sourceTree = "<group>"; };
 		57FB57D81C86581300AA590F /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
@@ -1122,6 +1124,7 @@
 				577E6FA71D18E45F00B5DA36 /* Executor.swift */,
 				57C2F1721D5E5A68005A214B /* BuilderType.swift */,
 				57A526521E42A07900B33A51 /* Geolocation.swift */,
+				57F216AB1E9DA1640084AAF9 /* Result.swift */,
 			);
 			path = Kinvey;
 			sourceTree = "<group>";
@@ -2070,6 +2073,7 @@
 				573851AC1D47C7EB00E4712A /* FileCache.swift in Sources */,
 				574912731C5932A700EA4F26 /* WritePolicy.swift in Sources */,
 				57BB56B41C4D8D2B00F6B548 /* LocalRequest.swift in Sources */,
+				57F216AC1E9DA1640084AAF9 /* Result.swift in Sources */,
 				57E1C3A71C17B4F300578974 /* Persistable.swift in Sources */,
 				57A526531E42A07900B33A51 /* Geolocation.swift in Sources */,
 				57FB57D91C86581300AA590F /* String.swift in Sources */,

--- a/Kinvey/Kinvey/CountOperation.swift
+++ b/Kinvey/Kinvey/CountOperation.swift
@@ -17,20 +17,20 @@ class CountOperation<T: Persistable>: ReadOperation<T, Int, Swift.Error>, ReadOp
         super.init(readPolicy: readPolicy, cache: cache, client: client)
     }
     
-    func executeLocal(_ completionHandler: ((Int?, Swift.Error?) -> Void)? = nil) -> Request {
+    func executeLocal(_ completionHandler: CompletionHandler? = nil) -> Request {
         let request = LocalRequest()
         request.execute { () -> Void in
             if let cache = self.cache {
                 let count = cache.count(query: self.query)
-                completionHandler?(count, nil)
+                completionHandler?(.success(count))
             } else {
-                completionHandler?(0, nil)
+                completionHandler?(.success(0))
             }
         }
         return request
     }
     
-    func executeNetwork(_ completionHandler: ((Int?, Swift.Error?) -> Void)? = nil) -> Request {
+    func executeNetwork(_ completionHandler: CompletionHandler? = nil) -> Request {
         let request = client.networkRequestFactory.buildAppDataCountByQuery(collectionName: T.collectionName(), query: query)
         request.execute() { data, response, error in
             if let response = response , response.isOK,
@@ -39,9 +39,9 @@ class CountOperation<T: Persistable>: ReadOperation<T, Int, Swift.Error>, ReadOp
                 let result = json as? [String : Int],
                 let count = result["count"]
             {
-                completionHandler?(count, nil)
+                completionHandler?(.success(count))
             } else {
-                completionHandler?(nil, buildError(data, response, error, self.client))
+                completionHandler?(.failure(buildError(data, response, error, self.client)))
             }
         }
         return request

--- a/Kinvey/Kinvey/DataStore.swift
+++ b/Kinvey/Kinvey/DataStore.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import PromiseKit
 
 class DataStoreTypeTag: Hashable {
     
@@ -76,7 +77,11 @@ open class DataStore<T: Persistable> where T: NSObject {
     open var ttl: TTL? {
         didSet {
             if let cache = cache {
-                cache.ttl = ttl != nil ? ttl!.1.toTimeInterval(ttl!.0) : nil
+                if let (value, unit) = ttl {
+                    cache.ttl = unit.toTimeInterval(value)
+                } else {
+                    cache.ttl = nil
+                }
             }
         }
     }
@@ -143,6 +148,25 @@ open class DataStore<T: Persistable> where T: NSObject {
      */
     @discardableResult
     open func find(byId id: String, readPolicy: ReadPolicy? = nil, completionHandler: @escaping ObjectCompletionHandler) -> Request {
+        return find(byId: id, readPolicy: readPolicy) { (result: Result<T, Swift.Error>) in
+            switch result {
+            case .success(let obj):
+                completionHandler(obj, nil)
+            case .failure(let error):
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    /**
+     Gets a single record using the `_id` of the record.
+     - parameter id: The `_id` value of the entity to be find
+     - parameter readPolicy: Enforces a different `ReadPolicy` otherwise use the client's `ReadPolicy`. Default value: `nil`
+     - parameter completionHandler: Completion handler to be called once the respose returns
+     - returns: A `Request` instance which will allow cancel the request later
+     */
+    @discardableResult
+    open func find(byId id: String, readPolicy: ReadPolicy? = nil, completionHandler: @escaping (Result<T, Swift.Error>) -> Void) -> Request {
         return find(id, readPolicy: readPolicy, completionHandler: completionHandler)
     }
     
@@ -165,11 +189,36 @@ open class DataStore<T: Persistable> where T: NSObject {
      */
     @discardableResult
     open func find(_ id: String, readPolicy: ReadPolicy? = nil, completionHandler: @escaping ObjectCompletionHandler) -> Request {
+        return find(id, readPolicy: readPolicy) { (result: Result<T, Swift.Error>) in
+            switch result {
+            case .success(let obj):
+                completionHandler(obj, nil)
+            case .failure(let error):
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    /**
+     Gets a single record using the `_id` of the record.
+     
+     PS: This method is just a shortcut for `findById()`
+     - parameter id: The `_id` value of the entity to be find
+     - parameter readPolicy: Enforces a different `ReadPolicy` otherwise use the client's `ReadPolicy`. Default value: `nil`
+     - parameter completionHandler: Completion handler to be called once the respose returns
+     - returns: A `Request` instance which will allow cancel the request later
+     */
+    @discardableResult
+    open func find(_ id: String, readPolicy: ReadPolicy? = nil, completionHandler: @escaping (Result<T, Swift.Error>) -> Void) -> Request {
         validate(id: id)
         
         let readPolicy = readPolicy ?? self.readPolicy
         let operation = GetOperation<T>(id: id, readPolicy: readPolicy, cache: cache, client: client)
-        let request = operation.execute(dispatchAsyncMainQueue(completionHandler))
+        let request = operation.execute { result in
+            DispatchQueue.main.async {
+                completionHandler(result)
+            }
+        }
         return request
     }
     
@@ -183,10 +232,34 @@ open class DataStore<T: Persistable> where T: NSObject {
      */
     @discardableResult
     open func find(_ query: Query = Query(), deltaSet: Bool? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping ArrayCompletionHandler) -> Request {
+        return find(query, deltaSet: deltaSet, readPolicy: readPolicy) { (result: Result<[T], Swift.Error>) in
+            switch result {
+            case .success(let objs):
+                completionHandler(objs, nil)
+            case .failure(let error):
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    /**
+     Gets a list of records that matches with the query passed by parameter.
+     - parameter query: The query used to filter the results
+     - parameter deltaSet: Enforces delta set cache otherwise use the client's `deltaSet` value. Default value: `false`
+     - parameter readPolicy: Enforces a different `ReadPolicy` otherwise use the client's `ReadPolicy`. Default value: `nil`
+     - parameter completionHandler: Completion handler to be called once the respose returns
+     - returns: A `Request` instance which will allow cancel the request later
+     */
+    @discardableResult
+    open func find(_ query: Query = Query(), deltaSet: Bool? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping (Result<[T], Swift.Error>) -> Void) -> Request {
         let readPolicy = readPolicy ?? self.readPolicy
         let deltaSet = deltaSet ?? self.deltaSet
         let operation = FindOperation<T>(query: Query(query: query, persistableType: T.self), deltaSet: deltaSet, readPolicy: readPolicy, cache: cache, client: client)
-        let request = operation.execute(dispatchAsyncMainQueue(completionHandler))
+        let request = operation.execute { result in
+            DispatchQueue.main.async {
+                completionHandler(result)
+            }
+        }
         return request
     }
     
@@ -199,24 +272,65 @@ open class DataStore<T: Persistable> where T: NSObject {
      */
     @discardableResult
     open func count(_ query: Query? = nil, readPolicy: ReadPolicy? = nil, completionHandler: IntCompletionHandler?) -> Request {
+        return count(query, readPolicy: readPolicy) { (result: Result<Int, Swift.Error>) in
+            switch result {
+            case .success(let count):
+                completionHandler?(count, nil)
+            case .failure(let error):
+                completionHandler?(nil, error)
+            }
+        }
+    }
+    
+    /**
+     Gets a count of how many records that matches with the (optional) query passed by parameter.
+     - parameter query: The query used to filter the results
+     - parameter readPolicy: Enforces a different `ReadPolicy` otherwise use the client's `ReadPolicy`. Default value: `nil`
+     - parameter completionHandler: Completion handler to be called once the respose returns
+     - returns: A `Request` instance which will allow cancel the request later
+     */
+    @discardableResult
+    open func count(_ query: Query? = nil, readPolicy: ReadPolicy? = nil, completionHandler: ((Result<Int, Swift.Error>) -> Void)?) -> Request {
         let readPolicy = readPolicy ?? self.readPolicy
         let operation = CountOperation<T>(query: query, readPolicy: readPolicy, cache: cache, client: client)
-        let request = operation.execute(dispatchAsyncMainQueue(completionHandler))
+        let request = operation.execute { result in
+            DispatchQueue.main.async {
+                completionHandler?(result)
+            }
+        }
         return request
     }
     
     @discardableResult
     open func group(keys: [String]? = nil, initialObject: JsonDictionary, reduceJSFunction: String, condition: NSPredicate? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping ([AggregationCustomResult<T>]?, Swift.Error?) -> Void) -> Request {
+        return group(keys: keys, initialObject: initialObject, reduceJSFunction: reduceJSFunction, condition: condition, readPolicy: readPolicy) { (result: Result<[AggregationCustomResult<T>], Swift.Error>) in
+            switch result {
+            case .success(let results):
+                completionHandler(results, nil)
+            case .failure(let error):
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    @discardableResult
+    open func group(keys: [String]? = nil, initialObject: JsonDictionary, reduceJSFunction: String, condition: NSPredicate? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping (Result<[AggregationCustomResult<T>], Swift.Error>) -> Void) -> Request {
         let readPolicy = readPolicy ?? self.readPolicy
         let keys = keys ?? []
         let aggregation: Aggregation = .custom(keys: keys, initialObject: initialObject, reduceJSFunction: reduceJSFunction)
         let operation = AggregateOperation<T>(aggregation: aggregation, condition: condition, readPolicy: readPolicy, cache: cache, client: client)
-        let request = operation.execute { results, error in
-            let array = results?.map {
-                return AggregationCustomResult<T>(value: T(JSON: $0)!, custom: $0)
+        let request = operation.execute { result in
+            switch result {
+            case .success(let results):
+                let array = results.map { AggregationCustomResult<T>(value: T(JSON: $0)!, custom: $0) }
+                DispatchQueue.main.async {
+                    completionHandler(.success(array))
+                }
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    completionHandler(.failure(error))
+                }
             }
-            let completionHandler = self.dispatchAsyncMainQueue(completionHandler)
-            completionHandler?(array, error)
         }
         return request
     }
@@ -224,100 +338,212 @@ open class DataStore<T: Persistable> where T: NSObject {
     @discardableResult
     open func group<Count: CountType>(count keys: [String], countType: Count.Type? = nil, condition: NSPredicate? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping
         ([AggregationCountResult<T, Count>]?, Swift.Error?) -> Void) -> Request {
+        return group(count: keys, countType: countType, condition: condition, readPolicy: readPolicy) { (result: Result<[AggregationCountResult<T, Count>], Swift.Error>) in
+            switch result {
+            case .success(let results):
+                completionHandler(results, nil)
+            case .failure(let error):
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    @discardableResult
+    open func group<Count: CountType>(count keys: [String], countType: Count.Type? = nil, condition: NSPredicate? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping
+        (Result<[AggregationCountResult<T, Count>], Swift.Error>) -> Void) -> Request {
         let readPolicy = readPolicy ?? self.readPolicy
         let aggregation: Aggregation = .count(keys: keys)
         let operation = AggregateOperation<T>(aggregation: aggregation, condition: condition, readPolicy: readPolicy, cache: cache, client: client)
-        let request = operation.execute { results, error in
-            let array = results?.map {
-                return AggregationCountResult<T, Count>(value: T(JSON: $0)!, count: $0[aggregation.resultKey] as! Count)
+        let request = operation.execute { result in
+            switch result {
+            case .success(let results):
+                let array = results.map { AggregationCountResult<T, Count>(value: T(JSON: $0)!, count: $0[aggregation.resultKey] as! Count) }
+                DispatchQueue.main.async {
+                    completionHandler(.success(array))
+                }
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    completionHandler(.failure(error))
+                }
             }
-            let completionHandler = self.dispatchAsyncMainQueue(completionHandler)
-            completionHandler?(array, error)
         }
         return request
     }
     
     @discardableResult
     open func group<Sum: AddableType>(keys: [String], sum: String, sumType: Sum.Type? = nil, condition: NSPredicate? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping ([AggregationSumResult<T, Sum>]?, Swift.Error?) -> Void) -> Request {
+        return group(keys: keys, sum: sum, sumType: sumType, condition: condition, readPolicy: readPolicy) { (result: Result<[AggregationSumResult<T, Sum>], Swift.Error>) in
+            switch result {
+            case .success(let results):
+                completionHandler(results, nil)
+            case .failure(let error):
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    @discardableResult
+    open func group<Sum: AddableType>(keys: [String], sum: String, sumType: Sum.Type? = nil, condition: NSPredicate? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping (Result<[AggregationSumResult<T, Sum>], Swift.Error>) -> Void) -> Request {
         let readPolicy = readPolicy ?? self.readPolicy
         let aggregation: Aggregation = .sum(keys: keys, sum: sum)
         let operation = AggregateOperation<T>(aggregation: aggregation, condition: condition, readPolicy: readPolicy, cache: cache, client: client)
-        let request = operation.execute { results, error in
-            let array = results?.map {
-                return AggregationSumResult<T, Sum>(value: T(JSON: $0)!, sum: $0[aggregation.resultKey] as! Sum)
+        let request = operation.execute { result in
+            switch result {
+            case .success(let results):
+                let array = results.map { AggregationSumResult<T, Sum>(value: T(JSON: $0)!, sum: $0[aggregation.resultKey] as! Sum) }
+                DispatchQueue.main.async {
+                    completionHandler(.success(array))
+                }
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    completionHandler(.failure(error))
+                }
             }
-            let completionHandler = self.dispatchAsyncMainQueue(completionHandler)
-            completionHandler?(array, error)
         }
         return request
     }
     
     @discardableResult
     open func group<Avg: AddableType>(keys: [String], avg: String, avgType: Avg.Type? = nil, condition: NSPredicate? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping ([AggregationAvgResult<T, Avg>]?, Swift.Error?) -> Void) -> Request {
+        return group(keys: keys, avg: avg, avgType: avgType, condition: condition, readPolicy: readPolicy) { (result: Result<[AggregationAvgResult<T, Avg>], Swift.Error>) in
+            switch result {
+            case .success(let results):
+                completionHandler(results, nil)
+            case .failure(let error):
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    @discardableResult
+    open func group<Avg: AddableType>(keys: [String], avg: String, avgType: Avg.Type? = nil, condition: NSPredicate? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping (Result<[AggregationAvgResult<T, Avg>], Swift.Error>) -> Void) -> Request {
         let readPolicy = readPolicy ?? self.readPolicy
         let aggregation: Aggregation = .avg(keys: keys, avg: avg)
         let operation = AggregateOperation<T>(aggregation: aggregation, condition: condition, readPolicy: readPolicy, cache: cache, client: client)
-        let request = operation.execute { results, error in
-            let array = results?.map {
-                return AggregationAvgResult<T, Avg>(value: T(JSON: $0)!, avg: $0[aggregation.resultKey] as! Avg)
+        let request = operation.execute { result in
+            switch result {
+            case .success(let results):
+                let array = results.map { AggregationAvgResult<T, Avg>(value: T(JSON: $0)!, avg: $0[aggregation.resultKey] as! Avg) }
+                DispatchQueue.main.async {
+                    completionHandler(.success(array))
+                }
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    completionHandler(.failure(error))
+                }
             }
-            let completionHandler = self.dispatchAsyncMainQueue(completionHandler)
-            completionHandler?(array, error)
         }
         return request
     }
     
     @discardableResult
     open func group<Min: MinMaxType>(keys: [String], min: String, minType: Min.Type? = nil, condition: NSPredicate? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping ([AggregationMinResult<T, Min>]?, Swift.Error?) -> Void) -> Request {
+        return group(keys: keys, min: min, minType: minType, condition: condition, readPolicy: readPolicy) { (result: Result<[AggregationMinResult<T, Min>], Swift.Error>) in
+            switch result {
+            case .success(let results):
+                completionHandler(results, nil)
+            case .failure(let error):
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    @discardableResult
+    open func group<Min: MinMaxType>(keys: [String], min: String, minType: Min.Type? = nil, condition: NSPredicate? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping (Result<[AggregationMinResult<T, Min>], Swift.Error>) -> Void) -> Request {
         let readPolicy = readPolicy ?? self.readPolicy
         let aggregation: Aggregation = .min(keys: keys, min: min)
         let operation = AggregateOperation<T>(aggregation: aggregation, condition: condition, readPolicy: readPolicy, cache: cache, client: client)
-        let request = operation.execute { results, error in
-            let array = results?.map {
-                return AggregationMinResult<T, Min>(value: T(JSON: $0)!, min: $0[aggregation.resultKey] as! Min)
+        let request = operation.execute { result in
+            switch result {
+            case .success(let results):
+                let array = results.map { AggregationMinResult<T, Min>(value: T(JSON: $0)!, min: $0[aggregation.resultKey] as! Min) }
+                DispatchQueue.main.async {
+                    completionHandler(.success(array))
+                }
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    completionHandler(.failure(error))
+                }
             }
-            let completionHandler = self.dispatchAsyncMainQueue(completionHandler)
-            completionHandler?(array, error)
         }
         return request
     }
     
     @discardableResult
     open func group<Max: MinMaxType>(keys: [String], max: String, maxType: Max.Type? = nil, condition: NSPredicate? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping ([AggregationMaxResult<T, Max>]?, Swift.Error?) -> Void) -> Request {
+        return group(keys: keys, max: max, maxType: maxType, condition: condition, readPolicy: readPolicy) { (result: Result<[AggregationMaxResult<T, Max>], Swift.Error>) in
+            switch result {
+            case .success(let results):
+                completionHandler(results, nil)
+            case .failure(let error):
+                completionHandler(nil, error)
+            }
+        }
+    }
+    
+    @discardableResult
+    open func group<Max: MinMaxType>(keys: [String], max: String, maxType: Max.Type? = nil, condition: NSPredicate? = nil, readPolicy: ReadPolicy? = nil, completionHandler: @escaping (Result<[AggregationMaxResult<T, Max>], Swift.Error>) -> Void) -> Request {
         let readPolicy = readPolicy ?? self.readPolicy
         let aggregation: Aggregation = .max(keys: keys, max: max)
         let operation = AggregateOperation<T>(aggregation: aggregation, condition: condition, readPolicy: readPolicy, cache: cache, client: client)
-        let request = operation.execute { results, error in
-            let array = results?.map {
-                return AggregationMaxResult<T, Max>(value: T(JSON: $0)!, max: $0[aggregation.resultKey] as! Max)
+        let request = operation.execute { result in
+            switch result {
+            case .success(let results):
+                let array = results.map { AggregationMaxResult<T, Max>(value: T(JSON: $0)!, max: $0[aggregation.resultKey] as! Max) }
+                DispatchQueue.main.async {
+                    completionHandler(.success(array))
+                }
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    completionHandler(.failure(error))
+                }
             }
-            let completionHandler = self.dispatchAsyncMainQueue(completionHandler)
-            completionHandler?(array, error)
         }
         return request
     }
     
     /// Creates or updates a record.
     @discardableResult
-    open func save(_ persistable: inout T, writePolicy: WritePolicy? = nil, completionHandler: ObjectCompletionHandler?) -> Request {
-        let writePolicy = writePolicy ?? self.writePolicy
-        let operation = SaveOperation<T>(persistable: persistable, writePolicy: writePolicy, sync: sync, cache: cache, client: client)
-        let request = operation.execute(dispatchAsyncMainQueue(completionHandler))
-        return request
+    open func save(_ persistable: T, writePolicy: WritePolicy? = nil, completionHandler: ObjectCompletionHandler? = nil) -> Request {
+        return save(persistable, writePolicy: writePolicy) { (result: Result<T, Swift.Error>) in
+            switch result {
+            case .success(let obj):
+                completionHandler?(obj, nil)
+            case .failure(let error):
+                completionHandler?(nil, error)
+            }
+        }
     }
     
     /// Creates or updates a record.
     @discardableResult
-    open func save(_ persistable: T, writePolicy: WritePolicy? = nil, completionHandler: ObjectCompletionHandler?) -> Request {
+    open func save(_ persistable: T, writePolicy: WritePolicy? = nil, completionHandler: ((Result<T, Swift.Error>) -> Void)? = nil) -> Request {
         let writePolicy = writePolicy ?? self.writePolicy
         let operation = SaveOperation<T>(persistable: persistable, writePolicy: writePolicy, sync: sync, cache: cache, client: client)
-        let request = operation.execute(dispatchAsyncMainQueue(completionHandler))
+        let request = operation.execute { result in
+            DispatchQueue.main.async {
+                completionHandler?(result)
+            }
+        }
         return request
     }
     
     /// Deletes a record.
     @discardableResult
     open func remove(_ persistable: T, writePolicy: WritePolicy? = nil, completionHandler: IntCompletionHandler?) throws -> Request {
+        return try remove(persistable, writePolicy: writePolicy) { (result: Result<Int, Swift.Error>) in
+            switch result {
+            case .success(let count):
+                completionHandler?(count, nil)
+            case .failure(let error):
+                completionHandler?(nil, error)
+            }
+        }
+    }
+    
+    /// Deletes a record.
+    @discardableResult
+    open func remove(_ persistable: T, writePolicy: WritePolicy? = nil, completionHandler: ((Result<Int, Swift.Error>) -> Void)?) throws -> Request {
         guard let id = persistable.entityId else {
             log.error("Object Id is missing")
             throw Error.objectIdMissing
@@ -328,6 +554,19 @@ open class DataStore<T: Persistable> where T: NSObject {
     /// Deletes a list of records.
     @discardableResult
     open func remove(_ array: [T], writePolicy: WritePolicy? = nil, completionHandler: IntCompletionHandler?) -> Request {
+        return remove(array, writePolicy: writePolicy) { (result: Result<Int, Swift.Error>) in
+            switch result {
+            case .success(let count):
+                completionHandler?(count, nil)
+            case .failure(let error):
+                completionHandler?(nil, error)
+            }
+        }
+    }
+    
+    /// Deletes a list of records.
+    @discardableResult
+    open func remove(_ array: [T], writePolicy: WritePolicy? = nil, completionHandler: ((Result<Int, Swift.Error>) -> Void)?) -> Request {
         var ids: [String] = []
         for persistable in array {
             if let id = persistable.entityId {
@@ -347,11 +586,28 @@ open class DataStore<T: Persistable> where T: NSObject {
     /// Deletes a record using the `_id` of the record.
     @discardableResult
     open func remove(byId id: String, writePolicy: WritePolicy? = nil, completionHandler: IntCompletionHandler?) -> Request {
+        return remove(byId: id, writePolicy: writePolicy) { (result: Result<Int, Swift.Error>) in
+            switch result {
+            case .success(let count):
+                completionHandler?(count, nil)
+            case .failure(let error):
+                completionHandler?(nil, error)
+            }
+        }
+    }
+    
+    /// Deletes a record using the `_id` of the record.
+    @discardableResult
+    open func remove(byId id: String, writePolicy: WritePolicy? = nil, completionHandler: ((Result<Int, Swift.Error>) -> Void)?) -> Request {
         validate(id: id)
 
         let writePolicy = writePolicy ?? self.writePolicy
         let operation = RemoveByIdOperation<T>(objectId: id, writePolicy: writePolicy, sync: sync, cache: cache, client: client)
-        let request = operation.execute(dispatchAsyncMainQueue(completionHandler))
+        let request = operation.execute { result in
+            DispatchQueue.main.async {
+                completionHandler?(result)
+            }
+        }
         return request
     }
     
@@ -365,6 +621,19 @@ open class DataStore<T: Persistable> where T: NSObject {
     /// Deletes a list of records using the `_id` of the records.
     @discardableResult
     open func remove(byIds ids: [String], writePolicy: WritePolicy? = nil, completionHandler: IntCompletionHandler?) -> Request {
+        return remove(byIds: ids, writePolicy: writePolicy) { (result: Result<Int, Swift.Error>) in
+            switch result {
+            case .success(let count):
+                completionHandler?(count, nil)
+            case .failure(let error):
+                completionHandler?(nil, error)
+            }
+        }
+    }
+    
+    /// Deletes a list of records using the `_id` of the records.
+    @discardableResult
+    open func remove(byIds ids: [String], writePolicy: WritePolicy? = nil, completionHandler: ((Result<Int, Swift.Error>) -> Void)?) -> Request {
         if ids.isEmpty {
             let message = "ids cannot be an empty array"
             log.severe(message)
@@ -378,49 +647,130 @@ open class DataStore<T: Persistable> where T: NSObject {
     /// Deletes a list of records that matches with the query passed by parameter.
     @discardableResult
     open func remove(_ query: Query = Query(), writePolicy: WritePolicy? = nil, completionHandler: IntCompletionHandler?) -> Request {
+        return remove(query, writePolicy: writePolicy) { (result: Result<Int, Swift.Error>) in
+            switch result {
+            case .success(let count):
+                completionHandler?(count, nil)
+            case .failure(let error):
+                completionHandler?(nil, error)
+            }
+        }
+    }
+    
+    /// Deletes a list of records that matches with the query passed by parameter.
+    @discardableResult
+    open func remove(_ query: Query = Query(), writePolicy: WritePolicy? = nil, completionHandler: ((Result<Int, Swift.Error>) -> Void)?) -> Request {
         let writePolicy = writePolicy ?? self.writePolicy
         let operation = RemoveByQueryOperation<T>(query: Query(query: query, persistableType: T.self), writePolicy: writePolicy, sync: sync, cache: cache, client: client)
-        let request = operation.execute(dispatchAsyncMainQueue(completionHandler))
+        let request = operation.execute { result in
+            DispatchQueue.main.async {
+                completionHandler?(result)
+            }
+        }
         return request
     }
     
     /// Deletes all the records.
     @discardableResult
     open func removeAll(_ writePolicy: WritePolicy? = nil, completionHandler: IntCompletionHandler?) -> Request {
+        return removeAll(writePolicy) { (result: Result<Int, Swift.Error>) in
+            switch result {
+            case .success(let count):
+                completionHandler?(count, nil)
+            case .failure(let error):
+                completionHandler?(nil, error)
+            }
+        }
+    }
+    
+    /// Deletes all the records.
+    @discardableResult
+    open func removeAll(_ writePolicy: WritePolicy? = nil, completionHandler: ((Result<Int, Swift.Error>) -> Void)?) -> Request {
         return remove(writePolicy: writePolicy, completionHandler: completionHandler)
     }
     
     /// Sends to the backend all the pending records in the local cache.
     @discardableResult
     open func push(timeout: TimeInterval? = nil, completionHandler: UIntErrorTypeArrayCompletionHandler? = nil) -> Request {
-        let completionHandler = dispatchAsyncMainQueue(completionHandler)
-        if type == .network {
-            completionHandler?(nil, [Error.invalidDataStoreType])
-            return LocalRequest()
+        return push(timeout: timeout) { (result: Result<UInt, [Swift.Error]>) in
+            switch result {
+            case .success(let count):
+                completionHandler?(count, nil)
+            case .failure(let errors):
+                completionHandler?(nil, errors)
+            }
         }
-        
-        let operation = PushOperation<T>(sync: sync, cache: cache, client: client)
-        let request = operation.execute(timeout: timeout, completionHandler: completionHandler)
+    }
+    
+    /// Sends to the backend all the pending records in the local cache.
+    @discardableResult
+    open func push(timeout: TimeInterval? = nil, completionHandler: ((Result<UInt, [Swift.Error]>) -> Void)? = nil) -> Request {
+        var request: Request!
+        Promise<UInt> { fulfill, reject in
+            if type == .network {
+                request = LocalRequest()
+                reject(MultipleErrors(errors: [Error.invalidDataStoreType]))
+            } else {
+                let operation = PushOperation<T>(sync: sync, cache: cache, client: client)
+                request = operation.execute(timeout: timeout) { result in
+                    switch result {
+                    case .success(let count):
+                        fulfill(count)
+                    case .failure(let errors):
+                        reject(MultipleErrors(errors: errors))
+                    }
+                }
+            }
+        }.then { count in
+            completionHandler?(.success(count))
+        }.catch { error in
+            let error = error as! MultipleErrors
+            completionHandler?(.failure(error.errors))
+        }
         return request
     }
     
     /// Gets the records from the backend that matches with the query passed by parameter and saves locally in the local cache.
     @discardableResult
     open func pull(_ query: Query = Query(), deltaSet: Bool? = nil, completionHandler: DataStore<T>.ArrayCompletionHandler? = nil) -> Request {
-        let completionHandler = dispatchAsyncMainQueue(completionHandler)
-        if type == .network {
-            completionHandler?(nil, Error.invalidDataStoreType)
-            return LocalRequest()
+        return pull(query, deltaSet: deltaSet) { (result: Result<[T], Swift.Error>) in
+            switch result {
+            case .success(let array):
+                completionHandler?(array, nil)
+            case .failure(let error):
+                completionHandler?(nil, error)
+            }
         }
-        
-        if self.syncCount() > 0 {
-            completionHandler?(nil, Error.invalidOperation(description: "You must push all pending sync items before new data is pulled. Call push() on the data store instance to push pending items, or purge() to remove them."))
-            return LocalRequest()
+    }
+    
+    /// Gets the records from the backend that matches with the query passed by parameter and saves locally in the local cache.
+    @discardableResult
+    open func pull(_ query: Query = Query(), deltaSet: Bool? = nil, completionHandler: ((Result<[T], Swift.Error>) -> Void)? = nil) -> Request {
+        var request: Request!
+        Promise<[T]> { fulfill, reject in
+            if type == .network {
+                request = LocalRequest()
+                reject(Error.invalidDataStoreType)
+            } else if self.syncCount() > 0 {
+                request = LocalRequest()
+                reject(Error.invalidOperation(description: "You must push all pending sync items before new data is pulled. Call push() on the data store instance to push pending items, or purge() to remove them."))
+            } else {
+                let deltaSet = deltaSet ?? self.deltaSet
+                let operation = PullOperation<T>(query: Query(query: query, persistableType: T.self), deltaSet: deltaSet, readPolicy: .forceNetwork, cache: cache, client: client)
+                request = operation.execute { result in
+                    switch result {
+                    case .success(let array):
+                        fulfill(array)
+                    case .failure(let error):
+                        reject(error)
+                    }
+                }
+            }
+        }.then { array in
+            completionHandler?(.success(array))
+        }.catch { error in
+            completionHandler?(.failure(error))
         }
-        
-        let deltaSet = deltaSet ?? self.deltaSet
-        let operation = PullOperation<T>(query: Query(query: query, persistableType: T.self), deltaSet: deltaSet, readPolicy: .forceNetwork, cache: cache, client: client)
-        let request = operation.execute(completionHandler)
         return request
     }
     
@@ -435,77 +785,102 @@ open class DataStore<T: Persistable> where T: NSObject {
     /// Calls `push` and then `pull` methods, so it sends all the pending records in the local cache and then gets the records from the backend and saves locally in the local cache.
     @discardableResult
     open func sync(_ query: Query = Query(), deltaSet: Bool? = nil, completionHandler: UIntArrayCompletionHandler? = nil) -> Request {
-        let completionHandler = dispatchAsyncMainQueue(completionHandler)
-        if type == .network {
-            completionHandler?(nil, nil, [Error.invalidDataStoreType])
-            return LocalRequest()
-        }
-        
-        let requests = MultiRequest()
-        let request = push() { count, errors in
-            if let count = count , errors == nil || errors!.isEmpty {
-                let deltaSet = deltaSet ?? self.deltaSet
-                let request = self.pull(query, deltaSet: deltaSet) { results, error in
-                    completionHandler?(count, results, error != nil ? [error!] : nil)
-                }
-                requests.addRequest(request)
-            } else {
-                completionHandler?(count, nil, errors)
+        return sync(query, deltaSet: deltaSet) { (result: Result<(UInt, [T]), [Swift.Error]>) in
+            switch result {
+            case .success(let count, let array):
+                completionHandler?(count, array, nil)
+            case .failure(let errors):
+                completionHandler?(nil, nil, errors)
             }
         }
-        requests.addRequest(request)
+    }
+    
+    /// Calls `push` and then `pull` methods, so it sends all the pending records in the local cache and then gets the records from the backend and saves locally in the local cache.
+    @discardableResult
+    open func sync(_ query: Query = Query(), deltaSet: Bool? = nil, completionHandler: ((Result<(UInt, [T]), [Swift.Error]>) -> Void)? = nil) -> Request {
+        let requests = MultiRequest()
+        Promise<(UInt, [T])> { fulfill, reject in
+            if type == .network {
+                requests += LocalRequest()
+                reject(MultipleErrors(errors: [Error.invalidDataStoreType]))
+            } else {
+                let request = push() { (result: Result<UInt, [Swift.Error]>) in
+                    switch result {
+                    case .success(let count):
+                        let deltaSet = deltaSet ?? self.deltaSet
+                        let request = self.pull(query, deltaSet: deltaSet) { (result: Result<[T], Swift.Error>) in
+                            switch result {
+                            case .success(let array):
+                                fulfill(count, array)
+                            case .failure(let error):
+                                reject(error)
+                            }
+                        }
+                        requests.addRequest(request)
+                    case .failure(let errors):
+                        reject(MultipleErrors(errors: errors))
+                    }
+                }
+                requests += request
+            }
+        }.then { count, array in
+            completionHandler?(.success(count, array))
+        }.catch { error in
+            let error = error as! MultipleErrors
+            completionHandler?(.failure(error.errors))
+        }
         return requests
     }
     
     /// Deletes all the pending changes in the local cache.
     @discardableResult
     open func purge(_ query: Query = Query(), completionHandler: DataStore<T>.IntCompletionHandler? = nil) -> Request {
-        let completionHandler = dispatchAsyncMainQueue(completionHandler)
-        
-        if type == .network {
-            completionHandler?(nil, Error.invalidDataStoreType)
-            return LocalRequest()
+        return purge(query) { (result: Result<Int, Swift.Error>) in
+            switch result {
+            case .success(let count):
+                completionHandler?(count, nil)
+            case .failure(let error):
+                completionHandler?(nil, error)
+            }
         }
-        
-        let executor = Executor()
-        
-        let operation = PurgeOperation<T>(sync: sync, cache: cache, client: client)
-        let request = operation.execute { (count, error: Swift.Error?) -> Void in
-            if let count = count {
-                executor.execute {
-                    self.pull(query) { (results, error) -> Void in
-                        completionHandler?(count, error)
+    }
+    
+    /// Deletes all the pending changes in the local cache.
+    @discardableResult
+    open func purge(_ query: Query = Query(), completionHandler: ((Result<Int, Swift.Error>) -> Void)? = nil) -> Request {
+        var request: Request!
+        Promise<Int> { fulfill, reject in
+            if type == .network {
+                request = LocalRequest()
+                reject(Error.invalidDataStoreType)
+            } else {
+                let executor = Executor()
+                
+                let operation = PurgeOperation<T>(sync: sync, cache: cache, client: client)
+                request = operation.execute { result in
+                    switch result {
+                    case .success(let count):
+                        executor.execute {
+                            self.pull(query) { (result: Result<[T], Swift.Error>) in
+                                switch result {
+                                case .success:
+                                    fulfill(count)
+                                case .failure(let error):
+                                    reject(error)
+                                }
+                            }
+                        }
+                    case .failure(let error):
+                        reject(error)
                     }
                 }
-            } else {
-                completionHandler?(count, error)
             }
+        }.then { count in
+            completionHandler?(.success(count))
+        }.catch { error in
+            completionHandler?(.failure(error))
         }
         return request
-    }
-    
-    //MARK: Dispatch Async Main Queue
-    
-    fileprivate func dispatchAsyncMainQueue<R, E>(_ completionHandler: ((R?, E?) -> Void)?) -> ((R?, E?) -> Void)? {
-        if let completionHandler = completionHandler {
-            return { (obj1: R?, obj2: E?) -> Void in
-                DispatchQueue.main.async(execute: { () -> Void in
-                    completionHandler(obj1, obj2)
-                })
-            }
-        }
-        return nil
-    }
-    
-    fileprivate func dispatchAsyncMainQueue<R1, R2, R3>(_ completionHandler: ((R1?, R2?, R3?) -> Void)?) -> ((R1?, R2?, R3?) -> Void)? {
-        if let completionHandler = completionHandler {
-            return { (obj1: R1?, obj2: R2?, obj3: R3?) -> Void in
-                DispatchQueue.main.async(execute: { () -> Void in
-                    completionHandler(obj1, obj2, obj3)
-                })
-            }
-        }
-        return nil
     }
     
     /// Clear all data for all collections.

--- a/Kinvey/Kinvey/Error.swift
+++ b/Kinvey/Kinvey/Error.swift
@@ -62,6 +62,10 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
     /// Error when the `appKey` and `appSecret` does not match with any Kinvey environment.
     case appNotFound(description: String)
     
+    /// Error when any operation is called but the client was not initiliazed yet.
+    case clientNotInitialized
+    
+    
     /// Error localized description.
     public var description: String {
         let bundle = Bundle(for: Client.self)
@@ -90,6 +94,8 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
             return NSLocalizedString("Error.invalidDataStoreType", bundle: bundle, comment: "")
         case .userWithoutEmailOrUsername:
             return NSLocalizedString("Error.userWithoutEmailOrUsername", bundle: bundle, comment: "")
+        case .clientNotInitialized:
+            return NSLocalizedString("Error.clientNotInitialized", bundle: bundle, comment: "")
         }
     }
     
@@ -175,5 +181,11 @@ public enum Error: Swift.Error, LocalizedError, CustomStringConvertible, CustomD
     static func buildUnauthorized(httpResponse: HTTPURLResponse?, data: Data?, json: [String : String]) -> Error {
         return unauthorized(httpResponse: httpResponse, data: data, error: json["error"]!, description: json["description"]!)
     }
+    
+}
+
+struct MultipleErrors: Swift.Error {
+    
+    let errors: [Swift.Error]
     
 }

--- a/Kinvey/Kinvey/Geolocation.swift
+++ b/Kinvey/Kinvey/Geolocation.swift
@@ -65,20 +65,23 @@ class GeoPointTransform: TransformOf<GeoPoint, [CLLocationDegrees]> {
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: inout GeoPoint, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
-    left <- (right.1, GeoPointTransform())
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- (map, GeoPointTransform())
 }
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: inout GeoPoint?, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
-    left <- (right.1, GeoPointTransform())
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- (map, GeoPointTransform())
 }
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: inout GeoPoint!, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
-    left <- (right.1, GeoPointTransform())
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- (map, GeoPointTransform())
 }
 
 func ==(lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Bool {

--- a/Kinvey/Kinvey/GetOperation.swift
+++ b/Kinvey/Kinvey/GetOperation.swift
@@ -20,8 +20,11 @@ internal class GetOperation<T: Persistable>: ReadOperation<T, T, Swift.Error>, R
     func executeLocal(_ completionHandler: CompletionHandler?) -> Request {
         let request = LocalRequest()
         request.execute { () -> Void in
-            let persistable = self.cache?.find(byId: self.id)
-            completionHandler?(persistable, nil)
+            if let persistable = self.cache?.find(byId: self.id) {
+                completionHandler?(.success(persistable))
+            } else {
+                completionHandler?(.failure(buildError(client: self.client)))
+            }
         }
         return request
     }
@@ -29,14 +32,15 @@ internal class GetOperation<T: Persistable>: ReadOperation<T, T, Swift.Error>, R
     func executeNetwork(_ completionHandler: CompletionHandler?) -> Request {
         let request = client.networkRequestFactory.buildAppDataGetById(collectionName: T.collectionName(), id: id)
         request.execute() { data, response, error in
-            if let response = response , response.isOK, let json = self.client.responseParser.parse(data) {
+            if let response = response,
+                response.isOK,
+                let json = self.client.responseParser.parse(data),
                 let obj = T(JSON: json)
-                if let obj = obj, let cache = self.cache {
-                    cache.save(entity: obj)
-                }
-                completionHandler?(obj, nil)
+            {
+                self.cache?.save(entity: obj)
+                completionHandler?(.success(obj))
             } else {
-                completionHandler?(nil, buildError(data, response, error, self.client))
+                completionHandler?(.failure(buildError(data, response, error, self.client)))
             }
         }
         return request

--- a/Kinvey/Kinvey/HttpRequest.swift
+++ b/Kinvey/Kinvey/HttpRequest.swift
@@ -169,8 +169,8 @@ extension URLRequest {
     public var description: String {
         var description = "\(httpMethod ?? "GET") \(url?.absoluteString ?? "")"
         if let headers = allHTTPHeaderFields {
-            for keyPair in headers {
-                description += "\n\(keyPair.0): \(keyPair.1)"
+            for (headerField, value) in headers {
+                description += "\n\(headerField): \(value)"
             }
         }
         if let body = httpBody, let bodyString = String(data: body, encoding: String.Encoding.utf8) {
@@ -186,8 +186,8 @@ extension HTTPURLResponse {
     /// Description for the NSHTTPURLResponse including url and headers
     open override var description: String {
         var description = "\(statusCode) \(HTTPURLResponse.localizedString(forStatusCode: statusCode))"
-        for keyPair in allHeaderFields {
-            description += "\n\(keyPair.0): \(keyPair.1)"
+        for (headerField, value) in allHeaderFields {
+            description += "\n\(headerField): \(value)"
         }
         return description
     }
@@ -415,8 +415,8 @@ internal class HttpRequest: TaskProgressRequest, Request {
             
             var headers = ""
             if let allHTTPHeaderFields = request.allHTTPHeaderFields {
-                for header in allHTTPHeaderFields {
-                    headers += "-H \"\(header.0): \(header.1)\" "
+                for (headerField, value) in allHTTPHeaderFields {
+                    headers += "-H \"\(headerField): \(value)\" "
                 }
             }
             return "curl -X \(String(describing: request.httpMethod)) \(headers) \(request.url!)"

--- a/Kinvey/Kinvey/HttpRequestFactory.swift
+++ b/Kinvey/Kinvey/HttpRequestFactory.swift
@@ -262,8 +262,8 @@ class HttpRequestFactory: RequestFactory {
     }
     
     fileprivate func ttlInSeconds(_ ttl: TTL?) -> UInt? {
-        if let ttl = ttl {
-            return UInt(ttl.1.toTimeInterval(ttl.0))
+        if let (value, unit) = ttl {
+            return UInt(unit.toTimeInterval(value))
         }
         return nil
     }

--- a/Kinvey/Kinvey/Kinvey.swift
+++ b/Kinvey/Kinvey/Kinvey.swift
@@ -70,10 +70,22 @@ let defaultTag = "kinvey"
 let userDocumentDirectory: String = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
 
 func buildError(_ data: Data?, _ response: URLResponse?, _ error: Swift.Error?, _ client: Client) -> Swift.Error {
-    return buildError(data, HttpResponse(response: response), error, client)
+    return buildError(data: data, urlResponse: response, error: error, client: client)
+}
+
+func buildError(data: Data?, urlResponse: URLResponse?, error: Swift.Error?, client: Client) -> Swift.Error {
+    return buildError(data: data, response: HttpResponse(response: urlResponse), error: error, client: client)
 }
 
 func buildError(_ data: Data?, _ response: Response?, _ error: Swift.Error?, _ client: Client) -> Swift.Error {
+    return buildError(data: data, response: response, error: error, client: client)
+}
+
+func buildError(client: Client) -> Swift.Error {
+    return buildError(data: nil, response: nil, error: nil, client: client)
+}
+
+func buildError(data: Data?, response: Response?, error: Swift.Error?, client: Client) -> Swift.Error {
     if let error = error {
         return error
     } else if let response = response , response.isUnauthorized,

--- a/Kinvey/Kinvey/Localizable.strings
+++ b/Kinvey/Kinvey/Localizable.strings
@@ -17,3 +17,5 @@
 "Error.invalidDataStoreType" = "DataStore type does not support this operation";
 
 "Error.userWithoutEmailOrUsername" = "User has no email or username";
+
+"Error.clientNotInitialized" = "Client is not initialized. Please call the initialize() method to initialize the client and try again.";

--- a/Kinvey/Kinvey/MemoryCache.swift
+++ b/Kinvey/Kinvey/MemoryCache.swift
@@ -53,8 +53,8 @@ class MemoryCache<T: Persistable>: Cache<T>, CacheType where T: NSObject {
             let kmd = entity.metadata!
             return (entity.entityId!, kmd.lmt!)
         }
-        for item in array {
-            results[item.0] = item.1
+        for (key, value) in array {
+            results[key] = value
         }
         return results
     }

--- a/Kinvey/Kinvey/Persistable.swift
+++ b/Kinvey/Kinvey/Persistable.swift
@@ -49,56 +49,65 @@ internal func kinveyMappingType(left: String, right: String) {
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- <T>(left: inout T, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
-    left <- right.1
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- map
 }
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- <T>(left: inout T?, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
-    left <- right.1
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- map
 }
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- <T>(left: inout T!, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
-    left <- right.1
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- map
 }
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- <T: BaseMappable>(left: inout T, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
-    left <- right.1
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- map
 }
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- <T: BaseMappable>(left: inout T?, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
-    left <- right.1
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- map
 }
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- <T: BaseMappable>(left: inout T!, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
-    left <- right.1
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- map
 }
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- <Transform: TransformType>(left: inout Transform.Object, right: (String, Map, Transform)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
-    left <- (right.1, right.2)
+    let (right, map, transform) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- (map, transform)
 }
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- <Transform: TransformType>(left: inout Transform.Object?, right: (String, Map, Transform)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
-    left <- (right.1, right.2)
+    let (right, map, transform) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- (map, transform)
 }
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (String, Map, Transform)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
-    left <- (right.1, right.2)
+    let (right, map, transform) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
+    left <- (map, transform)
 }
   
 class ListValueTransform<T: RealmSwift.Object>: TransformOf<List<T>, [JsonDictionary]> where T: BaseMappable {
@@ -126,12 +135,13 @@ class ListValueTransform<T: RealmSwift.Object>: TransformOf<List<T>, [JsonDictio
 }
 
 public func <-<T: BaseMappable>(lhs: List<T>, rhs: (String, Map)) {
+    let (_, map) = rhs
     var list = lhs
-    switch rhs.1.mappingType {
+    switch map.mappingType {
     case .fromJSON:
-        list <- (rhs.1, ListValueTransform<T>(list))
+        list <- (map, ListValueTransform<T>(list))
     case .toJSON:
-        list <- (rhs.1, ListValueTransform<T>(list))
+        list <- (map, ListValueTransform<T>(list))
     }
 }
 
@@ -159,13 +169,14 @@ class StringValueTransform: TransformOf<List<StringValue>, [String]> {
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: List<StringValue>, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
     var list = left
-    switch right.1.mappingType {
+    switch map.mappingType {
     case .toJSON:
-        list <- (right.1, StringValueTransform())
+        list <- (map, StringValueTransform())
     case .fromJSON:
-        list <- (right.1, StringValueTransform())
+        list <- (map, StringValueTransform())
         left.removeAll()
         left.append(objectsIn: list)
     }
@@ -195,13 +206,14 @@ class IntValueTransform: TransformOf<List<IntValue>, [Int]> {
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: List<IntValue>, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
     var list = left
-    switch right.1.mappingType {
+    switch map.mappingType {
     case .toJSON:
-        list <- (right.1, IntValueTransform())
+        list <- (map, IntValueTransform())
     case .fromJSON:
-        list <- (right.1, IntValueTransform())
+        list <- (map, IntValueTransform())
         left.removeAll()
         left.append(objectsIn: list)
     }
@@ -237,13 +249,14 @@ class FloatValueTransform: TransformOf<List<FloatValue>, [Float]> {
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: List<FloatValue>, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
     var list = left
-    switch right.1.mappingType {
+    switch map.mappingType {
     case .toJSON:
-        list <- (right.1, FloatValueTransform())
+        list <- (map, FloatValueTransform())
     case .fromJSON:
-        list <- (right.1, FloatValueTransform())
+        list <- (map, FloatValueTransform())
         left.removeAll()
         left.append(objectsIn: list)
     }
@@ -273,13 +286,14 @@ class DoubleValueTransform: TransformOf<List<DoubleValue>, [Double]> {
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: List<DoubleValue>, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
     var list = left
-    switch right.1.mappingType {
+    switch map.mappingType {
     case .toJSON:
-        list <- (right.1, DoubleValueTransform())
+        list <- (map, DoubleValueTransform())
     case .fromJSON:
-        list <- (right.1, DoubleValueTransform())
+        list <- (map, DoubleValueTransform())
         left.removeAll()
         left.append(objectsIn: list)
     }
@@ -309,13 +323,14 @@ class BoolValueTransform: TransformOf<List<BoolValue>, [Bool]> {
 
 /// Override operator used during the `propertyMapping(_:)` method.
 public func <- (left: List<BoolValue>, right: (String, Map)) {
-    kinveyMappingType(left: right.0, right: right.1.currentKey!)
+    let (right, map) = right
+    kinveyMappingType(left: right, right: map.currentKey!)
     var list = left
-    switch right.1.mappingType {
+    switch map.mappingType {
     case .toJSON:
-        list <- (right.1, BoolValueTransform())
+        list <- (map, BoolValueTransform())
     case .fromJSON:
-        list <- (right.1, BoolValueTransform())
+        list <- (map, BoolValueTransform())
         left.removeAll()
         left.append(objectsIn: list)
     }
@@ -368,13 +383,13 @@ extension Persistable {
     
     static func propertyMappingReverse() -> [String : [String]] {
         var results = [String : [String]]()
-        for keyPair in propertyMapping() {
-            var properties = results[keyPair.1]
+        for (key, value) in propertyMapping() {
+            var properties = results[value]
             if properties == nil {
                 properties = [String]()
             }
-            properties!.append(keyPair.0)
-            results[keyPair.1] = properties
+            properties!.append(key)
+            results[value] = properties
         }
         guard
             results[PersistableIdKey] != nil,

--- a/Kinvey/Kinvey/PurgeOperation.swift
+++ b/Kinvey/Kinvey/PurgeOperation.swift
@@ -9,7 +9,7 @@
 import Foundation
 import PromiseKit
 
-internal class PurgeOperation<T: Persistable>: SyncOperation<T, Int?, Swift.Error?> where T: NSObject {
+internal class PurgeOperation<T: Persistable>: SyncOperation<T, Int, Swift.Error> where T: NSObject {
     
     internal override init(sync: AnySync?, cache: AnyCache<T>?, client: Client) {
         super.init(sync: sync, cache: cache, client: client)
@@ -66,9 +66,9 @@ internal class PurgeOperation<T: Persistable>: SyncOperation<T, Int?, Swift.Erro
         }
         
         when(fulfilled: promises).then { results in
-            completionHandler?(results.count, nil)
+            completionHandler?(.success(results.count))
         }.catch { error in
-            completionHandler?(nil, error)
+            completionHandler?(.failure(error))
         }
         return requests
     }

--- a/Kinvey/Kinvey/PushOperation.swift
+++ b/Kinvey/Kinvey/PushOperation.swift
@@ -61,7 +61,7 @@ fileprivate class PushRequest: NSObject, Request {
     
 }
 
-internal class PushOperation<T: Persistable>: SyncOperation<T, UInt, [Swift.Error]?> where T: NSObject {
+internal class PushOperation<T: Persistable>: SyncOperation<T, UInt, [Swift.Error]> where T: NSObject {
     
     internal override init(sync: AnySync?, cache: AnyCache<T>?, client: Client) {
         super.init(sync: sync, cache: cache, client: client)
@@ -73,7 +73,11 @@ internal class PushOperation<T: Persistable>: SyncOperation<T, UInt, [Swift.Erro
         
         let collectionName = T.collectionName()
         let pushOperation = PushRequest(collectionName: collectionName) {
-            completionHandler?(count, errors.count > 0 ? errors : nil)
+            if errors.isEmpty {
+                completionHandler?(.success(count))
+            } else {
+                completionHandler?(.failure(errors))
+            }
         }
         
         let pendingBlockOperations = operationsQueue.pendingBlockOperations(forCollection: collectionName)

--- a/Kinvey/Kinvey/ReadOperation.swift
+++ b/Kinvey/Kinvey/ReadOperation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 internal class ReadOperation<T: Persistable, R, E>: Operation<T> where T: NSObject {
     
-    typealias CompletionHandler = (R?, E?) -> Void
+    typealias CompletionHandler = (Result<R, E>) -> Void
     
     let readPolicy: ReadPolicy
     
@@ -25,7 +25,7 @@ protocol ReadOperationType {
     
     associatedtype SuccessType
     associatedtype FailureType
-    typealias CompletionHandler = (SuccessType?, FailureType?) -> Void
+    typealias CompletionHandler = (Result<SuccessType, FailureType>) -> Void
     
     var readPolicy: ReadPolicy { get }
     
@@ -48,8 +48,8 @@ extension ReadOperationType {
             return executeNetwork(completionHandler)
         case .both:
             let request = MultiRequest()
-            executeLocal() { obj, error in
-                completionHandler?(obj, nil)
+            executeLocal() { result in
+                completionHandler?(result)
                 request.addRequest(self.executeNetwork(completionHandler))
             }
             return request

--- a/Kinvey/Kinvey/Result.swift
+++ b/Kinvey/Kinvey/Result.swift
@@ -1,0 +1,16 @@
+//
+//  Result.swift
+//  Kinvey
+//
+//  Created by Victor Hugo on 2017-04-11.
+//  Copyright © 2017 Kinvey. All rights reserved.
+//
+
+import Foundation
+
+public enum Result<SuccessType, FailureType> {
+    
+    case success(SuccessType)
+    case failure(FailureType)
+    
+}

--- a/Kinvey/Kinvey/SyncOperation.swift
+++ b/Kinvey/Kinvey/SyncOperation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 internal class SyncOperation<T: Persistable, R, E>: Operation<T> where T: NSObject {
     
-    internal typealias CompletionHandler = (R, E) -> Void
+    internal typealias CompletionHandler = (Result<R, E>) -> Void
     
     let sync: AnySync?
     

--- a/Kinvey/Kinvey/WriteOperation.swift
+++ b/Kinvey/Kinvey/WriteOperation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 internal class WriteOperation<T: Persistable, R>: Operation<T> where T: NSObject {
     
-    typealias CompletionHandler = (R, Swift.Error?) -> Void
+    typealias CompletionHandler = (Result<R, Swift.Error>) -> Void
     
     let writePolicy: WritePolicy
     let sync: AnySync?
@@ -20,6 +20,26 @@ internal class WriteOperation<T: Persistable, R>: Operation<T> where T: NSObject
         self.sync = sync
         super.init(cache: cache, client: client)
     }
+    
+}
+
+protocol WriteOperationType {
+    
+    associatedtype SuccessType
+    associatedtype FailureType
+    typealias CompletionHandler = (Result<SuccessType, FailureType>) -> Void
+    
+    var writePolicy: WritePolicy { get }
+    
+    @discardableResult
+    func executeLocal(_ completionHandler: CompletionHandler?) -> Request
+    
+    @discardableResult
+    func executeNetwork(_ completionHandler: CompletionHandler?) -> Request
+    
+}
+
+extension WriteOperationType {
     
     @discardableResult
     func execute(_ completionHandler: CompletionHandler?) -> Request {
@@ -32,20 +52,6 @@ internal class WriteOperation<T: Persistable, R>: Operation<T> where T: NSObject
         case .forceNetwork:
             return executeNetwork(completionHandler)
         }
-    }
-    
-    @discardableResult
-    func executeLocal(_ completionHandler: CompletionHandler?) -> Request {
-        let message = "Method \(#function) must be overridden"
-        log.severe(message)
-        fatalError(message)
-    }
-    
-    @discardableResult
-    func executeNetwork(_ completionHandler: CompletionHandler?) -> Request {
-        let message = "Method \(#function) must be overridden"
-        log.severe(message)
-        fatalError(message)
     }
     
 }

--- a/Kinvey/KinveyTests/AclTestCase.swift
+++ b/Kinvey/KinveyTests/AclTestCase.swift
@@ -145,7 +145,7 @@ class AclTestCase: StoreTestCase {
             
             store.push() { count, errors in
                 self.assertThread()
-                XCTAssertEqual(count, 0)
+                XCTAssertNil(count)
                 XCTAssertNotNil(errors)
                 
                 if let errors = errors {

--- a/Kinvey/KinveyTests/CacheMigrationTestCaseStep1.swift
+++ b/Kinvey/KinveyTests/CacheMigrationTestCaseStep1.swift
@@ -63,13 +63,13 @@ class CacheMigrationTestCaseStep1: XCTestCase {
         
         let store = DataStore<Person>.collection(.sync)
         
-        var person = Person()
+        let person = Person()
         person.firstName = "Victor"
         person.lastName = "Barros"
         
         weak var expectationSave = expectation(description: "Save")
         
-        store.save(&person) { (person, error) in
+        store.save(person) { (person, error) in
             XCTAssertNotNil(person)
             XCTAssertNil(error)
             

--- a/Kinvey/KinveyTests/CacheStoreTests.swift
+++ b/Kinvey/KinveyTests/CacheStoreTests.swift
@@ -98,7 +98,7 @@ class CacheStoreTests: StoreTestCase {
             
             store.find(byId: temporaryObjectId, readPolicy: .forceLocal) { (person, error) in
                 XCTAssertNil(person)
-                XCTAssertNil(error)
+                XCTAssertNotNil(error)
                 
                 expectationFind?.fulfill()
             }

--- a/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
+++ b/Kinvey/KinveyTests/DeltaSetCacheTestCase.swift
@@ -186,9 +186,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             weak var expectationCreate = expectation(description: "Create")
             
             let createOperation = SaveOperation<Person>(persistable: person, writePolicy: .forceNetwork, client: client)
-            createOperation.execute { (results, error) -> Void in
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
+            createOperation.execute { result in
+                switch result {
+                case .success:
+                    break
+                case .failure(let error):
+                    XCTFail()
+                }
                 
                 expectationCreate?.fulfill()
             }
@@ -372,9 +376,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             weak var expectationUpdate = expectation(description: "Update")
             
             let updateOperation = SaveOperation(persistable: person, writePolicy: .forceNetwork, client: client)
-            updateOperation.execute { (results, error) -> Void in
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
+            updateOperation.execute { result in
+                switch result {
+                case .success:
+                    break
+                case .failure:
+                    XCTFail()
+                }
                 
                 expectationUpdate?.fulfill()
             }
@@ -529,11 +537,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             let query = Query(format: "personId == %@", personId)
             query.persistableType = Person.self
             let createRemove = RemoveByQueryOperation<Person>(query: query, writePolicy: .forceNetwork, client: client)
-            createRemove.execute { (count, error) -> Void in
-                XCTAssertNotNil(count)
-                XCTAssertNil(error)
-                
-                XCTAssertEqual(count, 1)
+            createRemove.execute { result in
+                switch result {
+                case .success(let count):
+                    XCTAssertEqual(count, 1)
+                case .failure:
+                    XCTFail()
+                }
                 
                 expectationDelete?.fulfill()
             }
@@ -632,9 +642,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
             weak var expectationCreate = self.expectation(description: "Create")
             
             let createOperation = SaveOperation(persistable: person, writePolicy: .forceNetwork, client: self.client)
-            createOperation.execute { (results, error) -> Void in
-                XCTAssertNotNil(results)
-                XCTAssertNil(error)
+            createOperation.execute { result in
+                switch result {
+                case .success:
+                    break
+                case .failure:
+                    XCTFail()
+                }
                 
                 expectationCreate?.fulfill()
             }
@@ -948,9 +962,13 @@ class DeltaSetCacheTestCase: KinveyTestCase {
                 weak var expectationCreate = self.expectation(description: "Create")
                 
                 let createOperation = SaveOperation(persistable: person, writePolicy: .forceNetwork, client: self.client)
-                createOperation.execute { (results, error) -> Void in
-                    XCTAssertNotNil(results)
-                    XCTAssertNil(error)
+                createOperation.execute { result in
+                    switch result {
+                    case .success:
+                        break
+                    case .failure:
+                        XCTFail()
+                    }
                     
                     expectationCreate?.fulfill()
                 }

--- a/Kinvey/KinveyTests/KinveyTestCase.swift
+++ b/Kinvey/KinveyTests/KinveyTestCase.swift
@@ -48,6 +48,14 @@ struct HttpResponse {
     let statusCode: Int?
     let headerFields: [String : String]?
     let chunks: [ChunkData]?
+    let error: Swift.Error?
+    
+    init(error: Swift.Error) {
+        statusCode = nil
+        headerFields = nil
+        chunks = nil
+        self.error = error
+    }
     
     init(statusCode: Int? = nil, headerFields: [String : String]? = nil, chunks: [ChunkData]? = nil) {
         var headerFields = headerFields ?? [:]
@@ -59,6 +67,7 @@ struct HttpResponse {
         self.statusCode = statusCode
         self.headerFields = headerFields
         self.chunks = chunks
+        error = nil
     }
     
     init(statusCode: Int? = nil, headerFields: [String : String]? = nil, data: Data? = nil) {
@@ -175,17 +184,21 @@ extension XCTestCase {
         
         override func startLoading() {
             let responseObj = MockURLProtocol.completionHandler!(self.request)
-            let response = HTTPURLResponse(url: self.request.url!, statusCode: responseObj.statusCode ?? 200, httpVersion: "HTTP/1.1", headerFields: responseObj.headerFields)
-            self.client!.urlProtocol(self, didReceive: response!, cacheStoragePolicy: .notAllowed)
-            if let chunks = responseObj.chunks {
-                for chunk in chunks {
-                    self.client!.urlProtocol(self, didLoad: chunk.data)
-                    if let delay = chunk.delay {                        
-                        RunLoop.current.run(until: Date(timeIntervalSinceNow: delay))
+            if let error = responseObj.error {
+                self.client!.urlProtocol(self, didFailWithError: error)
+            } else {
+                let response = HTTPURLResponse(url: self.request.url!, statusCode: responseObj.statusCode ?? 200, httpVersion: "HTTP/1.1", headerFields: responseObj.headerFields)
+                self.client!.urlProtocol(self, didReceive: response!, cacheStoragePolicy: .notAllowed)
+                if let chunks = responseObj.chunks {
+                    for chunk in chunks {
+                        self.client!.urlProtocol(self, didLoad: chunk.data)
+                        if let delay = chunk.delay {                        
+                            RunLoop.current.run(until: Date(timeIntervalSinceNow: delay))
+                        }
                     }
                 }
+                self.client!.urlProtocolDidFinishLoading(self)
             }
-            self.client!.urlProtocolDidFinishLoading(self)
         }
         
         override func stopLoading() {
@@ -447,9 +460,15 @@ class KinveyTestCase: XCTestCase {
             
             weak var expectationDestroyUser = expectation(description: "Destroy User")
             
-            user.destroy { (error) -> Void in
+            user.destroy {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNil(error)
+                
+                switch $0 {
+                case .success:
+                    break
+                case .failure:
+                    XCTFail()
+                }
                 
                 expectationDestroyUser?.fulfill()
             }

--- a/Kinvey/KinveyTests/SyncStoreTests.swift
+++ b/Kinvey/KinveyTests/SyncStoreTests.swift
@@ -198,8 +198,13 @@ class SyncStoreTests: StoreTestCase {
             XCTAssertNil(count)
             XCTAssertNotNil(error)
             
-            if let error = error as? NSError {
-                XCTAssertEqual(error, Kinvey.Error.invalidDataStoreType as NSError)
+            if let error = error as? Kinvey.Error {
+                switch error {
+                case .invalidDataStoreType:
+                    break
+                default:
+                    XCTFail()
+                }
             }
             
             expectationPurge?.fulfill()
@@ -224,7 +229,7 @@ class SyncStoreTests: StoreTestCase {
         
         let query = Query(format: "acl.creator == %@", client.activeUser!.userId)
         store.purge(query) { (count, error) -> Void in
-            XCTAssertNotNil(count)
+            XCTAssertNil(count)
             XCTAssertNotNil(error)
             
             expectationPurge?.fulfill()
@@ -338,7 +343,7 @@ class SyncStoreTests: StoreTestCase {
         
         store.sync() { count, results, error in
             self.assertThread()
-            XCTAssertEqual(count, 0)
+            XCTAssertNil(count)
             XCTAssertNil(results)
             XCTAssertNotNil(error)
             
@@ -354,7 +359,8 @@ class SyncStoreTests: StoreTestCase {
     func testSyncNoCompletionHandler() {
         save()
         
-        let request = store.sync()
+        let request = store.sync { (_, _, _) in
+        }
         
         XCTAssertTrue(wait(toBeTrue: !request.executing))
     }
@@ -441,7 +447,8 @@ class SyncStoreTests: StoreTestCase {
     func testPushNoCompletionHandler() {
         save()
         
-        let request = store.push()
+        let request = store.push { (_, _) in
+        }
         
         XCTAssertTrue(wait(toBeTrue: !request.executing))
     }

--- a/Kinvey/KinveyTests/URLProtocols.swift
+++ b/Kinvey/KinveyTests/URLProtocols.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+let timeoutError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
+
 class TimeoutErrorURLProtocol: URLProtocol {
     
     override class func canInit(with request: URLRequest) -> Bool {

--- a/Kinvey/KinveyTests/UserTests.swift
+++ b/Kinvey/KinveyTests/UserTests.swift
@@ -84,9 +84,15 @@ class UserTests: KinveyTestCase {
         if let user = client.activeUser {
             weak var expectationDestroyUser = expectation(description: "Destroy User")
             
-            user.destroy(client: client, completionHandler: { (error) -> Void in
+            user.destroy(client: client, completionHandler: {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNil(error)
+                
+                switch $0 {
+                case .success:
+                    break
+                case .failure:
+                    XCTFail()
+                }
                 
                 expectationDestroyUser?.fulfill()
             })
@@ -117,9 +123,16 @@ class UserTests: KinveyTestCase {
             userId = user.userId
             weak var expectationDestroyUser = expectation(description: "Destroy User")
             
-            user.destroy(hard: true, completionHandler: { (error) -> Void in
+            user.destroy(hard: true, completionHandler: {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNil(error)
+                
+                switch $0 {
+                case .success:
+                    break
+                case .failure:
+                    XCTFail()
+                }
+                
                 expectationDestroyUser?.fulfill()
             })
             
@@ -171,9 +184,15 @@ class UserTests: KinveyTestCase {
         if let user = client.activeUser {
             weak var expectationDestroyUser = expectation(description: "Destroy User")
             
-            User.destroy(userId: user.userId, completionHandler: { (error) -> Void in
+            User.destroy(userId: user.userId, completionHandler: {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNil(error)
+                
+                switch $0 {
+                case .success:
+                    break
+                case .failure:
+                    XCTFail()
+                }
                 
                 expectationDestroyUser?.fulfill()
             })
@@ -201,9 +220,15 @@ class UserTests: KinveyTestCase {
             
             weak var expectationDestroyUser = expectation(description: "Destroy User")
             
-            User.destroy(userId: user.userId, hard: true, completionHandler: { (error) -> Void in
+            User.destroy(userId: user.userId, hard: true, completionHandler: {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNil(error)
+                
+                switch $0 {
+                case .success:
+                    break
+                case .failure:
+                    XCTFail()
+                }
                 
                 expectationDestroyUser?.fulfill()
             })
@@ -213,6 +238,42 @@ class UserTests: KinveyTestCase {
             }
             
             XCTAssertNil(client.activeUser)
+        }
+    }
+    
+    func testSignUpAndDestroyHardClassFuncTimeout() {
+        signUp()
+        
+        if let user = client.activeUser {
+            if useMockData {
+                setURLProtocol(TimeoutErrorURLProtocol.self)
+            }
+            defer {
+                if useMockData {
+                    setURLProtocol(nil)
+                }
+            }
+            
+            weak var expectationDestroyUser = expectation(description: "Destroy User")
+            
+            User.destroy(userId: user.userId, hard: true, completionHandler: {
+                XCTAssertTrue(Thread.isMainThread)
+                
+                switch $0 {
+                case .success:
+                    XCTFail()
+                case .failure:
+                    break
+                }
+                
+                expectationDestroyUser?.fulfill()
+            })
+            
+            waitForExpectations(timeout: defaultTimeout) { error in
+                expectationDestroyUser = nil
+            }
+            
+            XCTAssertNotNil(client.activeUser)
         }
     }
     
@@ -226,9 +287,16 @@ class UserTests: KinveyTestCase {
         if let user = client.activeUser {
             weak var expectationDestroyUser = expectation(description: "Destroy User")
             
-            User.destroy(userId: user.userId, client: client, completionHandler: { (error) -> Void in
+            User.destroy(userId: user.userId, client: client, completionHandler: {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNil(error)
+                
+                
+                switch $0 {
+                case .success:
+                    break
+                case .failure:
+                    XCTFail()
+                }
                 
                 expectationDestroyUser?.fulfill()
             })
@@ -690,9 +758,15 @@ class UserTests: KinveyTestCase {
             if let activeUser = client.activeUser {
                 weak var expectationDestroy = expectation(description: "Destroy")
                 
-                activeUser.destroy { (error) -> Void in
+                activeUser.destroy {
                     XCTAssertTrue(Thread.isMainThread)
-                    XCTAssertNil(error)
+                    
+                    switch $0 {
+                    case .success:
+                        break
+                    case .failure:
+                        XCTFail()
+                    }
                     
                     expectationDestroy?.fulfill()
                 }
@@ -757,9 +831,15 @@ class UserTests: KinveyTestCase {
             if let activeUser = client.activeUser {
                 weak var expectationDestroy = expectation(description: "Destroy")
                 
-                activeUser.destroy { (error) -> Void in
+                activeUser.destroy {
                     XCTAssertTrue(Thread.isMainThread)
-                    XCTAssertNil(error)
+                    
+                    switch $0 {
+                    case .success:
+                        break
+                    case .failure:
+                        XCTFail()
+                    }
                     
                     expectationDestroy?.fulfill()
                 }
@@ -887,9 +967,15 @@ class UserTests: KinveyTestCase {
         if let activeUser = client.activeUser {
             weak var expectationDestroy = expectation(description: "Destroy")
             
-            activeUser.destroy { (error) -> Void in
+            activeUser.destroy {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNotNil(error)
+                
+                switch $0 {
+                case .success:
+                    XCTFail()
+                case .failure:
+                    break
+                }
                 
                 expectationDestroy?.fulfill()
             }
@@ -901,69 +987,59 @@ class UserTests: KinveyTestCase {
     }
     
     func testSendEmailConfirmation() {
-        guard !useMockData else {
-            return
-        }
-        
-        signUp()
+        signUp(username: UUID().uuidString)
         
         XCTAssertNotNil(client.activeUser)
         
         if let user = client.activeUser {
-            weak var expectationSave = expectation(description: "Save")
-            
-            user.email = "\(user.username!)@kinvey.com"
-            
-            user.save() { user, error in
-                XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNil(error)
-                XCTAssertNotNil(user)
-                
-                expectationSave?.fulfill()
-            }
-            
-            waitForExpectations(timeout: defaultTimeout) { error in
-                expectationSave = nil
-            }
-            
-            class Mock204URLProtocol: URLProtocol {
-                
-                override class func canInit(with request: URLRequest) -> Bool {
-                    return true
+            do {
+                var json = user.toJSON()
+                json["email"] = "victor@kinvey.com"
+                mockResponse(json: json)
+                defer {
+                    setURLProtocol(nil)
                 }
                 
-                override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-                    return request
+                weak var expectationSave = expectation(description: "Save")
+                
+                user.email = "victor@kinvey.com"
+                user.save() { user, error in
+                    XCTAssertTrue(Thread.isMainThread)
+                    XCTAssertNotNil(user)
+                    XCTAssertNil(error)
+                    
+                    expectationSave?.fulfill()
                 }
                 
-                fileprivate override func startLoading() {
-                    let response = HTTPURLResponse(url: request.url!, statusCode: 204, httpVersion: "HTTP/1.1", headerFields: [:])!
-                    client!.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-                    client!.urlProtocol(self, didLoad: Data())
-                    client!.urlProtocolDidFinishLoading(self)
+                waitForExpectations(timeout: defaultTimeout) { error in
+                    expectationSave = nil
+                }
+            }
+            
+            do {
+                mockResponse(statusCode: 204, data: Data())
+                defer {
+                    setURLProtocol(nil)
                 }
                 
-                fileprivate override func stopLoading() {
+                weak var expectationSendEmailConfirmation = expectation(description: "Send Email Confirmation")
+                
+                user.sendEmailConfirmation {
+                    XCTAssertTrue(Thread.isMainThread)
+                    
+                    switch $0 {
+                    case .success:
+                        break
+                    case .failure:
+                        XCTFail()
+                    }
+                    
+                    expectationSendEmailConfirmation?.fulfill()
                 }
                 
-            }
-            
-            setURLProtocol(Mock204URLProtocol.self)
-            defer {
-                setURLProtocol(nil)
-            }
-
-            weak var expectationSendEmailConfirmation = expectation(description: "Send Email Confirmation")
-            
-            user.sendEmailConfirmation { error in
-                XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNil(error)
-                
-                expectationSendEmailConfirmation?.fulfill()
-            }
-            
-            waitForExpectations(timeout: defaultTimeout) { error in
-                expectationSendEmailConfirmation = nil
+                waitForExpectations(timeout: defaultTimeout) { error in
+                    expectationSendEmailConfirmation = nil
+                }
             }
         }
     }
@@ -1090,9 +1166,15 @@ class UserTests: KinveyTestCase {
             
             weak var expectationResetPassword = expectation(description: "Reset Password")
             
-            user.resetPassword { error in
+            user.resetPassword {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNil(error)
+                
+                switch $0 {
+                case .success:
+                    break
+                case .failure:
+                    XCTFail()
+                }
                 
                 expectationResetPassword?.fulfill()
             }
@@ -1115,9 +1197,15 @@ class UserTests: KinveyTestCase {
         if let user = client.activeUser {
             weak var expectationResetPassword = expectation(description: "Reset Password")
             
-            user.resetPassword { error in
+            user.resetPassword {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNil(error)
+                
+                switch $0 {
+                case .success:
+                    break
+                case .failure:
+                    XCTFail()
+                }
                 
                 expectationResetPassword?.fulfill()
             }
@@ -1156,9 +1244,15 @@ class UserTests: KinveyTestCase {
             
             weak var expectationResetPassword = expectation(description: "Reset Password")
             
-            user.resetPassword { error in
+            user.resetPassword {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNotNil(error)
+                
+                switch $0 {
+                case .success:
+                    XCTFail()
+                case .failure:
+                    break
+                }
                 
                 expectationResetPassword?.fulfill()
             }
@@ -1197,9 +1291,15 @@ class UserTests: KinveyTestCase {
             
             weak var expectationResetPassword = expectation(description: "Reset Password")
             
-            user.resetPassword { error in
+            user.resetPassword {
                 XCTAssertTrue(Thread.isMainThread)
-                XCTAssertNotNil(error)
+                
+                switch $0 {
+                case .success:
+                    XCTFail()
+                case .failure:
+                    break
+                }
                 
                 expectationResetPassword?.fulfill()
             }
@@ -1217,9 +1317,15 @@ class UserTests: KinveyTestCase {
         
         weak var expectationForgotUsername = expectation(description: "Forgot Username")
         
-        User.forgotUsername(email: "\(UUID().uuidString)@kinvey.com") { error in
+        User.forgotUsername(email: "\(UUID().uuidString)@kinvey.com") {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNil(error)
+            
+            switch $0 {
+            case .success:
+                break
+            case .failure:
+                XCTFail()
+            }
             
             expectationForgotUsername?.fulfill()
         }
@@ -1234,9 +1340,15 @@ class UserTests: KinveyTestCase {
         
         weak var expectationForgotUsername = expectation(description: "Forgot Username")
         
-        User.forgotUsername(email: "\(UUID().uuidString)@kinvey.com") { error in
+        User.forgotUsername(email: "\(UUID().uuidString)@kinvey.com") {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertNotNil(error)
+            
+            switch $0 {
+            case .success:
+                XCTFail()
+            case .failure:
+                break
+            }
             
             expectationForgotUsername?.fulfill()
         }
@@ -1320,6 +1432,151 @@ class UserTests: KinveyTestCase {
         
         waitForExpectations(timeout: defaultTimeout) { error in
             expectationFacebookLogin = nil
+        }
+        
+        client.activeUser = nil
+    }
+    
+    func testFacebookLoginTimeout() {
+        setURLProtocol(TimeoutErrorURLProtocol.self)
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        weak var expectationFacebookLogin = expectation(description: "Facebook Login")
+        
+        let fakeFacebookData = [
+            "access_token": "AAAD30ogoDZCYBAKS50rOwCxMR7tIX8F90YDyC3vp63j0IvyCU0MELE2QMLnsWXKo2LcRgwA51hFr1UUpqXkSHu4lCj4VZCIuGG7DHZAHuZArzjvzTZAwQ",
+            "expires": "5105388"
+        ]
+        User.login(authSource: .facebook, fakeFacebookData) { user, error in
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+            
+            if let error = error {
+                let error = error as NSError
+                XCTAssertEqual(error.domain, NSURLErrorDomain)
+                XCTAssertEqual(error.code, NSURLErrorTimedOut)
+            }
+            
+            expectationFacebookLogin?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { error in
+            expectationFacebookLogin = nil
+        }
+        
+        client.activeUser = nil
+    }
+    
+    func testFacebookLoginWithoutClientInitialization() {
+        setURLProtocol(TimeoutErrorURLProtocol.self)
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        let client = Client()
+        
+        weak var expectationFacebookLogin = expectation(description: "Facebook Login")
+        
+        let fakeFacebookData = [
+            "access_token": "AAAD30ogoDZCYBAKS50rOwCxMR7tIX8F90YDyC3vp63j0IvyCU0MELE2QMLnsWXKo2LcRgwA51hFr1UUpqXkSHu4lCj4VZCIuGG7DHZAHuZArzjvzTZAwQ",
+            "expires": "5105388"
+        ]
+        User.login(authSource: .facebook, fakeFacebookData, client: client) { user, error in
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+            
+            if let error = error {
+                XCTAssertTrue(error is Kinvey.Error)
+                
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .clientNotInitialized:
+                        break
+                    default:
+                        XCTFail()
+                    }
+                }
+            }
+            
+            expectationFacebookLogin?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { error in
+            expectationFacebookLogin = nil
+        }
+        
+        client.activeUser = nil
+    }
+    
+    func testLoginWithUsernameAndPasswordTimeout() {
+        setURLProtocol(TimeoutErrorURLProtocol.self)
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        weak var expectationLogin = expectation(description: "Login")
+        
+        User.login(
+            username: UUID().uuidString,
+            password: UUID().uuidString
+        ) { user, error in
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+            
+            if let error = error {
+                let error = error as NSError
+                XCTAssertEqual(error.domain, NSURLErrorDomain)
+                XCTAssertEqual(error.code, NSURLErrorTimedOut)
+            }
+            
+            expectationLogin?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { error in
+            expectationLogin = nil
+        }
+        
+        client.activeUser = nil
+    }
+    
+    func testLoginWithUsernameAndPasswordWithoutClientInitialization() {
+        setURLProtocol(TimeoutErrorURLProtocol.self)
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        let client = Client()
+        
+        weak var expectationLogin = expectation(description: "Login")
+        
+        User.login(
+            username: UUID().uuidString,
+            password: UUID().uuidString,
+            client: client
+        ) { user, error in
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+            
+            if let error = error {
+                XCTAssertTrue(error is Kinvey.Error)
+                
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .clientNotInitialized:
+                        break
+                    default:
+                        XCTFail()
+                    }
+                }
+            }
+            
+            expectationLogin?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { error in
+            expectationLogin = nil
         }
         
         client.activeUser = nil
@@ -2084,6 +2341,255 @@ class UserTests: KinveyTestCase {
             waitForExpectations(timeout: defaultTimeout) { (error) in
                 expectationFind = nil
             }
+        }
+    }
+    
+    func testClientNotInitialized() {
+        let client = Client()
+        
+        weak var expectationSignUp = expectation(description: "Sign Up")
+        
+        User.signup(client: client) { (result: Result<User, Swift.Error>) in
+            XCTAssertTrue(Thread.isMainThread)
+            
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertTrue(error is Kinvey.Error)
+                if let error = error as? Kinvey.Error {
+                    switch error {
+                    case .clientNotInitialized:
+                        XCTAssertEqual(error.description, "Client is not initialized. Please call the initialize() method to initialize the client and try again.")
+                        break
+                    default:
+                        XCTFail()
+                    }
+                }
+            }
+            
+            expectationSignUp?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { (error) in
+            expectationSignUp = nil
+        }
+    }
+    
+    func testMICParseCode() {
+        let redirectURI = URL(string: "myCustomURIScheme://")!
+        let url = URL(string: "myCustomURIScheme://?code_not_present=1234")!
+        let code = MIC.parseCode(redirectURI: redirectURI, url: url)
+        XCTAssertNil(code)
+    }
+    
+    func testMICLoginTimeout() {
+        setURLProtocol(TimeoutErrorURLProtocol.self)
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        weak var expectationLogin = expectation(description: "Login")
+        
+        MIC.login(redirectURI: URL(string: "myCustomURIScheme://")!, code: "1234") { result in
+            XCTAssertTrue(Thread.isMainThread)
+            
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                let error = error as NSError
+                XCTAssertEqual(error.domain, NSURLErrorDomain)
+                XCTAssertEqual(error.code, NSURLErrorTimedOut)
+            }
+            
+            expectationLogin?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { (error) in
+            expectationLogin = nil
+        }
+    }
+    
+    func testMICLoginTimeoutDuringLoginCall() {
+        var count = 0
+        mockResponse { (request) -> HttpResponse in
+            defer {
+                count += 1
+            }
+            switch count {
+            case 0:
+                return HttpResponse(
+                    statusCode: 200,
+                    json: [
+                        "_socialIdentity" : [
+                            "kinveyAuth" : [
+                                "access_token" : UUID().uuidString,
+                                "token_type" : "Bearer",
+                                "expires_in" : 59,
+                                "refresh_token" : UUID().uuidString
+                            ]
+                        ]
+                    ]
+                )
+            case 1:
+                return HttpResponse(error: timeoutError)
+            default:
+                XCTFail()
+                return HttpResponse(statusCode: 200, data: Data())
+            }
+        }
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        weak var expectationLogin = expectation(description: "Login")
+        
+        MIC.login(redirectURI: URL(string: "myCustomURIScheme://")!, code: "1234") { result in
+            XCTAssertTrue(Thread.isMainThread)
+            
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                let error = error as NSError
+                XCTAssertEqual(error.domain, NSURLErrorDomain)
+                XCTAssertEqual(error.code, NSURLErrorTimedOut)
+            }
+            
+            expectationLogin?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { (error) in
+            expectationLogin = nil
+        }
+    }
+    
+    func testMICLoginUsernamePasswordTimeout() {
+        setURLProtocol(TimeoutErrorURLProtocol.self)
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        weak var expectationLogin = expectation(description: "Login")
+        
+        MIC.login(redirectURI: URL(string: "myCustomURIScheme://")!, username: UUID().uuidString, password: UUID().uuidString) { result in
+            XCTAssertTrue(Thread.isMainThread)
+            
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                let error = error as NSError
+                XCTAssertEqual(error.domain, NSURLErrorDomain)
+                XCTAssertEqual(error.code, NSURLErrorTimedOut)
+            }
+            
+            expectationLogin?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { (error) in
+            expectationLogin = nil
+        }
+    }
+    
+    func testMICLoginUsernamePasswordTimeoutDuringTempLoginURI() {
+        var count = 0
+        mockResponse { (request) -> HttpResponse in
+            defer {
+                count += 1
+            }
+            switch count {
+            case 0:
+                return HttpResponse(
+                    statusCode: 200,
+                    json: [
+                        "temp_login_uri" : "https://auth.kinvey.com/oauth/authenticate/\(UUID().uuidString)"
+                    ]
+                )
+            case 1:
+                return HttpResponse(error: timeoutError)
+            default:
+                XCTFail()
+                return HttpResponse(statusCode: 200, data: Data())
+            }
+        }
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        weak var expectationLogin = expectation(description: "Login")
+        
+        MIC.login(redirectURI: URL(string: "myCustomURIScheme://")!, username: UUID().uuidString, password: UUID().uuidString) { result in
+            XCTAssertTrue(Thread.isMainThread)
+            
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                let error = error as NSError
+                XCTAssertEqual(error.domain, NSURLErrorDomain)
+                XCTAssertEqual(error.code, NSURLErrorTimedOut)
+            }
+            
+            expectationLogin?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { (error) in
+            expectationLogin = nil
+        }
+    }
+    
+    func testMICLoginUsernamePasswordTimeoutDuringLoginCall() {
+        var count = 0
+        mockResponse { (request) -> HttpResponse in
+            defer {
+                count += 1
+            }
+            switch count {
+            case 0:
+                return HttpResponse(
+                    statusCode: 200,
+                    json: [
+                        "temp_login_uri" : "https://auth.kinvey.com/oauth/authenticate/\(UUID().uuidString)"
+                    ]
+                )
+            case 1:
+                return HttpResponse(
+                    statusCode: 302,
+                    headerFields: ["Location" : "myCustomURIScheme://?code=1234"],
+                    data: Data()
+                )
+            case 2:
+                return HttpResponse(error: timeoutError)
+            default:
+                XCTFail()
+                return HttpResponse(statusCode: 200, data: Data())
+            }
+        }
+        defer {
+            setURLProtocol(nil)
+        }
+        
+        weak var expectationLogin = expectation(description: "Login")
+        
+        MIC.login(redirectURI: URL(string: "myCustomURIScheme://")!, username: UUID().uuidString, password: UUID().uuidString) { result in
+            XCTAssertTrue(Thread.isMainThread)
+            
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                let error = error as NSError
+                XCTAssertEqual(error.domain, NSURLErrorDomain)
+                XCTAssertEqual(error.code, NSURLErrorTimedOut)
+            }
+            
+            expectationLogin?.fulfill()
+        }
+        
+        waitForExpectations(timeout: defaultTimeout) { (error) in
+            expectationLogin = nil
         }
     }
 


### PR DESCRIPTION
#### Description

This is a proposal to discuss.
Result enum solves the problem of having a never reached code, for example:

```
CustomEndpoint.execute("echo", params: CustomEndpoint.Params(params)) { (response: [EchoType]?, error: Swift.Error?) in
    if let response = response {
        // reachable
    } else if let error = error {
        // reachable
    } else {
        // will never be reached!
    }
}
```

and now could  be done this way:

```
CustomEndpoint.execute("echo", params: CustomEndpoint.Params(params)) { (result: Result<[EchoType]>) in
    switch result {
    case .success(let response):
        // handle success
    case .failure(let error):
        // handle failure
    }
}
```

#### Changes

Overload methods in the follow classes:

* FileStore
* User
* Client
* CustomEndpoint
* DataStore

#### Tests

* Unit tests changed accordingly 