### PR TITLE
MLIBZ-1788: user refresh

### DIFF
--- a/Kinvey/Kinvey/User.swift
+++ b/Kinvey/Kinvey/User.swift
@@ -360,7 +360,7 @@ open class User: NSObject, Credential, Mappable {
         return request
     }
     
-    /// Gets a `User` instance using the `userId` property.
+    /// Refresh the user's data.
     @discardableResult
     open func refresh(completionHandler: VoidHandler? = nil) -> Request {
         let request = client.networkRequestFactory.buildUserGet(userId: userId)


### PR DESCRIPTION
#### Description

Missing feature from v1 which allows an user instance to refresh data

#### Changes

* Added a new method in the `User` class

#### Tests

* Unit Test added with mocking response
